### PR TITLE
as much as it hurts, async is holding us back

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -11,13 +11,13 @@ use std::{sync::Arc, time::Duration};
 const FRAMEBUFFER_WIDTH: usize = 1920;
 const FRAMEBUFFER_HEIGHT: usize = 1080;
 
-async fn invoke_parse_pixelflut_commands(
+fn invoke_parse_pixelflut_commands(
     input: &[u8],
     fb: &Arc<FrameBuffer>,
     parser_state: ParserState,
 ) {
     let mut stream = DevNullTcpStream::default();
-    parse_pixelflut_commands(input, fb, &mut stream, parser_state).await;
+    parse_pixelflut_commands(input, fb, &mut stream, parser_state);
 }
 
 fn from_elem(c: &mut Criterion) {
@@ -33,8 +33,7 @@ fn from_elem(c: &mut Criterion) {
         |b, input| {
             let fb = Arc::new(FrameBuffer::new(FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT));
             let parser_state = ParserState::default();
-            b.to_async(tokio::runtime::Runtime::new().unwrap())
-                .iter(|| invoke_parse_pixelflut_commands(input, &fb, parser_state.clone()));
+            b.iter(|| invoke_parse_pixelflut_commands(input, &fb, parser_state.clone()));
         },
     );
 

--- a/src/sinks/vnc.rs
+++ b/src/sinks/vnc.rs
@@ -6,7 +6,7 @@ use rusttype::{point, Font, Scale};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast;
-use tokio::sync::mpsc::Sender;
+use std::sync::mpsc::Sender;
 use vncserver::{
     rfb_framebuffer_malloc, rfb_get_screen, rfb_init_server, rfb_mark_rect_as_modified,
     rfb_run_event_loop, RfbScreenInfoPtr,
@@ -105,7 +105,7 @@ impl<'a> VncServer<'a> {
                 height_up_to_stats_text as i32,
             );
             self.statistics_tx
-                .blocking_send(StatisticsEvent::FrameRendered)
+                .send(StatisticsEvent::FrameRendered)
                 .unwrap();
 
             if !self.statistics_information_rx.is_empty() {

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -4,10 +4,11 @@ use std::{
     cmp::max,
     collections::{hash_map::Entry, HashMap},
     fs::File,
+    sync::mpsc::Receiver,
     net::IpAddr,
     time::{Duration, Instant},
 };
-use tokio::sync::{broadcast, mpsc::Receiver};
+use tokio::sync::{broadcast};
 
 pub const STATS_REPORT_INTERVAL: Duration = Duration::from_millis(1000);
 pub const STATS_SLIDING_WINDOW_SIZE: usize = 5;
@@ -106,7 +107,7 @@ impl Statistics {
         let mut last_save_file_written = Instant::now();
         let mut statistics_information_event = StatisticsInformationEvent::default();
 
-        while let Some(statistics_update) = self.statistics_rx.recv().await {
+        while let Ok(statistics_update) = self.statistics_rx.recv() {
             self.statistic_events += 1;
             match statistics_update {
                 StatisticsEvent::ConnectionCreated { ip } => {


### PR DESCRIPTION
About my testing: for some reason, I can't push loopback further than ~40Gbit/s on my machine, no matter the connections.

On the other hand, if I only flood with a single connection, I get ~10Gbit/s with sturmflut with the async version, with breakwater running at 102% cpu. With the sync version, I get ~14Gbit/s, still at 102% cpu usage.

I'm not saying that I like the sync version more than the async version, but it is definitely noticeably faster. If I hammer them with 10 connections, both versions perform similar in terms of bandwidth.

Tests are not changed to sync yet