### PR TITLE
new bench that tests random command ordering, to confuse the branch predictor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "log",
  "number_prefix",
  "prometheus_exporter",
+ "rand",
  "rstest",
  "rusttype",
  "serde",
@@ -603,6 +604,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +956,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1005,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ vncserver = { version ="0.2", optional = true}
 [dev-dependencies]
 criterion = {version = "0.5", features = ["async_tokio"]}
 rstest = "0.17"
+rand = "0.8.5"
 
 [features]
 default = ["vnc"]

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -6,9 +6,9 @@ use breakwater::{
 use criterion::{
     BenchmarkId, Criterion, {criterion_group, criterion_main},
 };
-use std::{sync::Arc, time::Duration};
 use rand::seq::SliceRandom;
 use rand::thread_rng;
+use std::{sync::Arc, time::Duration};
 
 const FRAMEBUFFER_WIDTH: usize = 1920;
 const FRAMEBUFFER_HEIGHT: usize = 1080;
@@ -23,7 +23,8 @@ async fn invoke_parse_pixelflut_commands(
 }
 
 fn from_elem(c: &mut Criterion) {
-    let mut draw_commands = get_commands_to_draw_rect(FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT, 0x123456);
+    let mut draw_commands =
+        get_commands_to_draw_rect(FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT, 0x123456);
     let ordered_draw_commands = draw_commands.join("");
 
     c.bench_with_input(

--- a/src/test/helpers/pixelflut_commands.rs
+++ b/src/test/helpers/pixelflut_commands.rs
@@ -1,9 +1,9 @@
-pub fn get_commands_to_draw_rect(width: usize, height: usize, color: u32) -> String {
-    let mut draw_commands = String::new();
+pub fn get_commands_to_draw_rect(width: usize, height: usize, color: u32) -> Vec<String> {
+    let mut draw_commands = Vec::new();
 
     for x in 0..width {
         for y in 0..height {
-            draw_commands += &format!("PX {x} {y} {color:06x}\n");
+            draw_commands.push(format!("PX {x} {y} {color:06x}\n"));
         }
     }
 


### PR DESCRIPTION
The current implementation takes a significant hit from a random load, as it turns out that the branch predictor is pretty good at predicting predictable stuff.

(11ms vs 19ms on my machine)