### PR TITLE
refactor: Simplify Parse trait by using Vec<u8> instead of AyncWriteExt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,8 +213,6 @@ dependencies = [
  "enum_dispatch",
  "memchr",
  "pixelbomber",
- "snafu",
- "trait-variant",
 ]
 
 [[package]]
@@ -1802,17 +1800,6 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "trait-variant"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,6 @@ dependencies = [
  "memchr",
  "pixelbomber",
  "snafu",
- "tokio",
  "trait-variant",
 ]
 

--- a/breakwater-parser/Cargo.toml
+++ b/breakwater-parser/Cargo.toml
@@ -17,7 +17,6 @@ breakwater-core.workspace = true
 enum_dispatch.workspace = true
 memchr.workspace = true
 snafu.workspace = true
-tokio.workspace = true
 trait-variant.workspace = true
 
 [dev-dependencies]

--- a/breakwater-parser/Cargo.toml
+++ b/breakwater-parser/Cargo.toml
@@ -16,8 +16,6 @@ breakwater-core.workspace = true
 
 enum_dispatch.workspace = true
 memchr.workspace = true
-snafu.workspace = true
-trait-variant.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/breakwater-parser/src/assembler.rs
+++ b/breakwater-parser/src/assembler.rs
@@ -1,8 +1,6 @@
 use std::arch::asm;
 
-use tokio::io::AsyncWriteExt;
-
-use crate::{Parser, ParserError};
+use crate::Parser;
 
 const PARSER_LOOKAHEAD: usize = "PX 1234 1234 rrggbbaa\n".len(); // Longest possible command
 
@@ -10,11 +8,7 @@ const PARSER_LOOKAHEAD: usize = "PX 1234 1234 rrggbbaa\n".len(); // Longest poss
 pub struct AssemblerParser {}
 
 impl Parser for AssemblerParser {
-    async fn parse(
-        &mut self,
-        buffer: &[u8],
-        _stream: impl AsyncWriteExt + Send + Unpin,
-    ) -> Result<usize, ParserError> {
+    fn parse(&mut self, buffer: &[u8], _response: &mut Vec<u8>) -> usize {
         let mut last_byte_parsed = 0;
 
         // This loop does nothing and should be seen as a placeholder
@@ -33,7 +27,7 @@ impl Parser for AssemblerParser {
             )
         }
 
-        Ok(last_byte_parsed)
+        last_byte_parsed
     }
 
     fn parser_lookahead(&self) -> usize {

--- a/breakwater-parser/src/lib.rs
+++ b/breakwater-parser/src/lib.rs
@@ -2,8 +2,6 @@
 #![feature(portable_simd)]
 
 use enum_dispatch::enum_dispatch;
-use snafu::Snafu;
-use tokio::io::AsyncWriteExt;
 
 #[cfg(target_arch = "x86_64")]
 pub mod assembler;
@@ -11,21 +9,10 @@ pub mod memchr;
 pub mod original;
 pub mod refactored;
 
-#[derive(Debug, Snafu)]
-pub enum ParserError {
-    #[snafu(display("Failed to write to TCP socket"))]
-    WriteToTcpSocket { source: std::io::Error },
-}
-
 #[enum_dispatch(ParserImplementation)]
-// According to https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html
-#[trait_variant::make(SendParser: Send)]
 pub trait Parser {
-    async fn parse(
-        &mut self,
-        buffer: &[u8],
-        stream: impl AsyncWriteExt + Send + Unpin,
-    ) -> Result<usize, ParserError>;
+    /// Returns the last byte parsed. The next parsing loop will again contain all data that was not parsed.
+    fn parse(&mut self, buffer: &[u8], response: &mut Vec<u8>) -> usize;
 
     // Sadly this cant be const (yet?) (https://github.com/rust-lang/rust/issues/71971 and https://github.com/rust-lang/rfcs/pull/2632)
     fn parser_lookahead(&self) -> usize;

--- a/breakwater-parser/src/memchr.rs
+++ b/breakwater-parser/src/memchr.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
 use breakwater_core::framebuffer::FrameBuffer;
-use tokio::io::AsyncWriteExt;
 
-use crate::{Parser, ParserError};
+use crate::Parser;
 
 pub struct MemchrParser {
     fb: Arc<FrameBuffer>,
@@ -16,11 +15,7 @@ impl MemchrParser {
 }
 
 impl Parser for MemchrParser {
-    async fn parse(
-        &mut self,
-        buffer: &[u8],
-        _stream: impl AsyncWriteExt + Send + Unpin,
-    ) -> Result<usize, ParserError> {
+    fn parse(&mut self, buffer: &[u8], _response: &mut Vec<u8>) -> usize {
         let mut last_char_after_newline = 0;
         for newline in memchr::memchr_iter(b'\n', buffer) {
             // TODO Use get_unchecked everywhere
@@ -68,7 +63,7 @@ impl Parser for MemchrParser {
             }
         }
 
-        Ok(last_char_after_newline.saturating_sub(1))
+        last_char_after_newline.saturating_sub(1)
     }
 
     fn parser_lookahead(&self) -> usize {


### PR DESCRIPTION
This **should** also improve performance for write only traffic (which is 99% of the traffic) as we can remove the overhead of async and error handling.

We (@fabi321, @bits0rcerer and @sbernauer) tested the performance during GPN22 and come to the following measurements:

| Hardware           | before | after |
|--------------------|--------|-------|
| @sbernauer Laptop  | 16G    | 21G   |
| @fabi321s Laptop    | 26G    | 28G   |
| @bits0rcerer Laptop | 78G    | 82G   |
| 80 core Ampere server (arm) | 420G | 407G |

So to sum it up it's faster on all x86 machines, but somehow slower on the big arm server. I really don't know how removing async and error-handling make thing slower but I guess the x86 speedup is more important.