### PR TITLE
feat: Print nicer error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Try to improve performance by calling `madvise` to inform Kernel we are reading sequentially ([#24])
 - Expose metric on denied connection counts ([#26])
+- Print nicer error messages ([#XX])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Try to improve performance by calling `madvise` to inform Kernel we are reading sequentially ([#24])
 - Expose metric on denied connection counts ([#26])
-- Print nicer error messages ([#XX])
+- Print nicer error messages ([#32])
 
 ### Changed
 
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 [#24]: https://github.com/sbernauer/breakwater/pull/24
 [#25]: https://github.com/sbernauer/breakwater/pull/25
 [#26]: https://github.com/sbernauer/breakwater/pull/26
+[#32]: https://github.com/sbernauer/breakwater/pull/32
 
 ## [0.14.0] - 2024-05-30 at GPN 22 :)
 

--- a/breakwater/src/main.rs
+++ b/breakwater/src/main.rs
@@ -78,6 +78,7 @@ pub enum Error {
 }
 
 #[tokio::main]
+#[snafu::report]
 async fn main() -> Result<(), Error> {
     if env::var("RUST_LOG").is_err() {
         env::set_var("RUST_LOG", "info")


### PR DESCRIPTION
From
`Error: StartVncServer { source: ReadFontFile { source: Os { code: 2, kind: NotFound, message: "No such file or directory" }, font_file: "212" } }`
to
```
Error: Failed to start VNC server

Caused by these errors (recent errors listed first):
  1: Failed to read font from file 212
  2: No such file or directory (os error 2)
```