### PR TITLE
refactor!: Decouple breakwater-parser to make it easier to integrate elsewhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
 name = "breakwater-core"
 version = "0.15.0"
 dependencies = [
+ "breakwater-parser",
  "const_format",
  "tokio",
 ]
@@ -272,7 +273,6 @@ dependencies = [
 name = "breakwater-parser"
 version = "0.15.0"
 dependencies = [
- "breakwater-core",
  "criterion",
  "enum_dispatch",
  "memchr",

--- a/breakwater-core/Cargo.toml
+++ b/breakwater-core/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
+breakwater-parser = { path = "../breakwater-parser"}
 const_format.workspace = true
 tokio.workspace = true
 

--- a/breakwater-core/Cargo.toml
+++ b/breakwater-core/Cargo.toml
@@ -8,7 +8,7 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-breakwater-parser = { path = "../breakwater-parser"}
+breakwater-parser.workspace = true
 const_format.workspace = true
 tokio.workspace = true
 

--- a/breakwater-core/src/framebuffer.rs
+++ b/breakwater-core/src/framebuffer.rs
@@ -89,9 +89,4 @@ impl breakwater_parser::FrameBuffer for FrameBuffer {
     fn set(&self, x: usize, y: usize, rgba: u32) {
         self.set(x, y, rgba)
     }
-
-    #[inline]
-    fn get_buffer(&self) -> &[u32] {
-        self.get_buffer()
-    }
 }

--- a/breakwater-core/src/framebuffer.rs
+++ b/breakwater-core/src/framebuffer.rs
@@ -70,22 +70,27 @@ impl FrameBuffer {
 }
 
 impl breakwater_parser::FrameBuffer for FrameBuffer {
+    #[inline]
     fn get_width(&self) -> usize {
         self.get_width()
     }
 
+    #[inline]
     fn get_height(&self) -> usize {
         self.get_height()
     }
 
+    #[inline]
     fn get_unchecked(&self, x: usize, y: usize) -> u32 {
         self.get_unchecked(x, y)
     }
 
+    #[inline]
     fn set(&self, x: usize, y: usize, rgba: u32) {
         self.set(x, y, rgba)
     }
 
+    #[inline]
     fn get_buffer(&self) -> &[u32] {
         self.get_buffer()
     }

--- a/breakwater-core/src/framebuffer.rs
+++ b/breakwater-core/src/framebuffer.rs
@@ -81,7 +81,7 @@ impl breakwater_parser::FrameBuffer for FrameBuffer {
     }
 
     #[inline]
-    fn get_unchecked(&self, x: usize, y: usize) -> u32 {
+    unsafe fn get_unchecked(&self, x: usize, y: usize) -> u32 {
         self.get_unchecked(x, y)
     }
 

--- a/breakwater-core/src/framebuffer.rs
+++ b/breakwater-core/src/framebuffer.rs
@@ -1,5 +1,6 @@
 use std::slice;
 
+
 pub struct FrameBuffer {
     width: usize,
     height: usize,
@@ -65,5 +66,27 @@ impl FrameBuffer {
     pub fn as_bytes(&self) -> &[u8] {
         let len_in_bytes = self.buffer.len() * 4;
         unsafe { slice::from_raw_parts(self.buffer.as_ptr() as *const u8, len_in_bytes) }
+    }
+}
+
+impl breakwater_parser::FrameBuffer for FrameBuffer {
+    fn get_width(&self) -> usize {
+        self.get_width()
+    }
+
+    fn get_height(&self) -> usize {
+        self.get_height()
+    }
+
+    fn get_unchecked(&self, x: usize, y: usize) -> u32 {
+        self.get_unchecked(x, y)
+    }
+
+    fn set(&self, x: usize, y: usize, rgba: u32) {
+        self.set(x, y, rgba)
+    }
+
+    fn get_buffer(&self) -> &[u32] {
+        self.get_buffer()
     }
 }

--- a/breakwater-parser/Cargo.toml
+++ b/breakwater-parser/Cargo.toml
@@ -12,8 +12,6 @@ name = "parsing"
 harness = false
 
 [dependencies]
-breakwater-core.workspace = true
-
 enum_dispatch.workspace = true
 memchr.workspace = true
 

--- a/breakwater-parser/src/assembler.rs
+++ b/breakwater-parser/src/assembler.rs
@@ -5,6 +5,7 @@ use crate::{FrameBuffer, Parser};
 const PARSER_LOOKAHEAD: usize = "PX 1234 1234 rrggbbaa\n".len(); // Longest possible command
 
 #[derive(Default)]
+#[allow(dead_code)]
 pub struct AssemblerParser<FB: FrameBuffer> {
     help_text: &'static [u8],
     alt_help_text: &'static [u8],

--- a/breakwater-parser/src/assembler.rs
+++ b/breakwater-parser/src/assembler.rs
@@ -1,13 +1,17 @@
-use std::arch::asm;
+use std::{arch::asm, sync::Arc};
 
-use crate::Parser;
+use crate::{FrameBuffer, Parser};
 
 const PARSER_LOOKAHEAD: usize = "PX 1234 1234 rrggbbaa\n".len(); // Longest possible command
 
 #[derive(Default)]
-pub struct AssemblerParser {}
+pub struct AssemblerParser<FB: FrameBuffer> {
+    help_text: &'static [u8],
+    alt_help_text: &'static [u8],
+    fb: Arc<FB>,
+}
 
-impl Parser for AssemblerParser {
+impl<FB: FrameBuffer> Parser for AssemblerParser<FB> {
     fn parse(&mut self, buffer: &[u8], _response: &mut Vec<u8>) -> usize {
         let mut last_byte_parsed = 0;
 

--- a/breakwater-parser/src/lib.rs
+++ b/breakwater-parser/src/lib.rs
@@ -42,14 +42,9 @@ pub trait FrameBuffer {
             None
         }
     }
+    /// # Safety
+    /// make sure x and y are in bounds
     unsafe fn get_unchecked(&self, x: usize, y: usize) -> u32;
 
     fn set(&self, x: usize, y: usize, rgba: u32);
-
-    #[inline]
-    fn as_bytes(&self) -> &[u8] {
-        let len_in_bytes = self.get_buffer().len() * 4;
-        unsafe { std::slice::from_raw_parts(self.get_buffer().as_ptr() as *const u8, len_in_bytes) }
-    }
-    fn get_buffer(&self) -> &[u32];
 }

--- a/breakwater-parser/src/lib.rs
+++ b/breakwater-parser/src/lib.rs
@@ -37,12 +37,12 @@ pub trait FrameBuffer {
     #[inline]
     fn get(&self, x: usize, y: usize) -> Option<u32> {
         if x < self.get_width() && y < self.get_height() {
-            Some(self.get_unchecked(x, y))
+            Some(unsafe { self.get_unchecked(x, y) })
         } else {
             None
         }
     }
-    fn get_unchecked(&self, x: usize, y: usize) -> u32;
+    unsafe fn get_unchecked(&self, x: usize, y: usize) -> u32;
 
     fn set(&self, x: usize, y: usize, rgba: u32);
 

--- a/breakwater-parser/src/memchr.rs
+++ b/breakwater-parser/src/memchr.rs
@@ -1,20 +1,24 @@
 use std::sync::Arc;
 
-use breakwater_core::framebuffer::FrameBuffer;
+use crate::{FrameBuffer, Parser};
 
-use crate::Parser;
-
-pub struct MemchrParser {
-    fb: Arc<FrameBuffer>,
+pub struct MemchrParser<FB: FrameBuffer> {
+    help_text: &'static [u8],
+    alt_help_text: &'static [u8],
+    fb: Arc<FB>,
 }
 
-impl MemchrParser {
-    pub fn new(fb: Arc<FrameBuffer>) -> Self {
-        Self { fb }
+impl<FB: FrameBuffer> MemchrParser<FB> {
+    pub fn new(fb: Arc<FB>, help_text: &'static [u8], alt_help_text: &'static [u8]) -> Self {
+        Self {
+            fb,
+            help_text,
+            alt_help_text,
+        }
     }
 }
 
-impl Parser for MemchrParser {
+impl<FB: FrameBuffer> Parser for MemchrParser<FB> {
     fn parse(&mut self, buffer: &[u8], _response: &mut Vec<u8>) -> usize {
         let mut last_char_after_newline = 0;
         for newline in memchr::memchr_iter(b'\n', buffer) {

--- a/breakwater-parser/src/memchr.rs
+++ b/breakwater-parser/src/memchr.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::{FrameBuffer, Parser};
 
+#[allow(dead_code)]
 pub struct MemchrParser<FB: FrameBuffer> {
     help_text: &'static [u8],
     alt_help_text: &'static [u8],

--- a/breakwater-parser/src/original.rs
+++ b/breakwater-parser/src/original.rs
@@ -96,7 +96,7 @@ impl<FB: FrameBuffer> Parser for OriginalParser<FB> {
                             }
 
                             let alpha_comp = 0xff - alpha;
-                            let current = self.fb.get_unchecked(x, y);
+                            let current = unsafe { self.fb.get_unchecked(x, y)} ;
                             let r = (rgba >> 16) & 0xff;
                             let g = (rgba >> 8) & 0xff;
                             let b = rgba & 0xff;

--- a/breakwater-parser/src/refactored.rs
+++ b/breakwater-parser/src/refactored.rs
@@ -9,6 +9,7 @@ use crate::{
 
 const PARSER_LOOKAHEAD: usize = "PX 1234 1234 rrggbbaa\n".len(); // Longest possible command
 
+#[allow(dead_code)]
 pub struct RefactoredParser <FB: FrameBuffer> {
     connection_x_offset: usize,
     connection_y_offset: usize,

--- a/breakwater-parser/src/refactored.rs
+++ b/breakwater-parser/src/refactored.rs
@@ -154,7 +154,7 @@ impl<FB: FrameBuffer> RefactoredParser<FB> {
         }
 
         let alpha_comp = 0xff - alpha;
-        let current = self.fb.get_unchecked(x, y);
+        let current = unsafe { self.fb.get_unchecked(x, y) };
         let r = (rgba >> 16) & 0xff;
         let g = (rgba >> 8) & 0xff;
         let b = rgba & 0xff;

--- a/breakwater/src/server.rs
+++ b/breakwater/src/server.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::{cmp::min, net::IpAddr, sync::Arc, time::Duration};
 
 use breakwater_core::{framebuffer::FrameBuffer, CONNECTION_DENIED_TEXT};
+use breakwater_core::{ALT_HELP_TEXT, HELP_TEXT};
 use breakwater_parser::{original::OriginalParser, Parser};
 use log::{debug, info, warn};
 use memadvise::{Advice, MemAdviseError};
@@ -178,7 +179,7 @@ pub async fn handle_connection(
 
     // Not using `ParserImplementation` to avoid the dynamic dispatch.
     // let mut parser = ParserImplementation::Simple(SimpleParser::new(fb));
-    let mut parser = OriginalParser::new(fb);
+    let mut parser = OriginalParser::new(fb, HELP_TEXT, ALT_HELP_TEXT);
     let parser_lookahead = parser.parser_lookahead();
 
     // If we send e.g. an StatisticsEvent::BytesRead for every time we read something from the socket the statistics thread would go crazy.


### PR DESCRIPTION
This pull request hides breakwaters framebuffer implementation behind a trait and decouples `breakwater-parser` from `breakwater-core` (in fact reverses the dependency).
This allows other project to use the breakwater magic but implement their own framebuffer.

These change do not introduce dynamic dispatch so runtime performance should™ not be affected.