### PR TITLE
Original parser fixes

### DIFF
--- a/breakwater-parser/src/original.rs
+++ b/breakwater-parser/src/original.rs
@@ -171,7 +171,7 @@ impl Parser for OriginalParser {
                 }
             } else if current_command & 0xffff_ffff == SIZE_PATTERN {
                 i += 4;
-                last_byte_parsed = i - 1;
+                last_byte_parsed = i + 1;
 
                 response.extend_from_slice(
                     format!("SIZE {} {}\n", self.fb.get_width(), self.fb.get_height()).as_bytes(),
@@ -179,7 +179,7 @@ impl Parser for OriginalParser {
                 continue;
             } else if current_command & 0xffff_ffff == HELP_PATTERN {
                 i += 4;
-                last_byte_parsed = i - 1;
+                last_byte_parsed = i + 1;
 
                 match help_count {
                     0..=2 => {

--- a/breakwater-parser/src/original.rs
+++ b/breakwater-parser/src/original.rs
@@ -154,7 +154,8 @@ impl Parser for OriginalParser {
 
                 // TODO: Support alpha channel (behind alpha feature flag)
                 self.fb.set(x as usize, y as usize, rgba & 0x00ff_ffff);
-
+                //                 P   B   XX  YY  RGBA
+                last_byte_parsed = i + 1 + 2 + 2 + 4;
                 i += 10;
                 continue;
             } else if current_command & 0x00ff_ffff_ffff_ffff == OFFSET_PATTERN {


### PR DESCRIPTION
This PR fixes:
 - an off by two error in the original parser while parsing `HELP` and `SIZE` commands. (I think this should save 2 loop iterations in the parser loop)
 - set `last_byte_parsed` for the binary `PB` command