### PR TITLE
fix: two fixes around native display output

### DIFF
--- a/breakwater/src/sinks/native_display.rs
+++ b/breakwater/src/sinks/native_display.rs
@@ -192,7 +192,7 @@ impl<FB: FrameBuffer> NativeDisplaySink<FB> {
     fn window_attributes(&self) -> WindowAttributes {
         Window::default_attributes()
             .with_title("Pixelflut server (breakwater)")
-            .with_inner_size(winit::dpi::LogicalSize::new(
+            .with_inner_size(winit::dpi::PhysicalSize::new(
                 self.fb.get_width() as u32,
                 self.fb.get_height() as u32,
             ))

--- a/breakwater/src/sinks/native_display.rs
+++ b/breakwater/src/sinks/native_display.rs
@@ -2,7 +2,7 @@ use std::{num::NonZero, sync::Arc};
 
 use async_trait::async_trait;
 use breakwater_parser::FrameBuffer;
-use log::debug;
+use log::{debug, warn};
 use snafu::{ResultExt, Snafu};
 use softbuffer::{Context, Surface};
 use tokio::{
@@ -155,6 +155,16 @@ impl<FB: FrameBuffer> ApplicationHandler for NativeDisplaySink<FB> {
             WindowEvent::RedrawRequested => {
                 let window = surface.window().clone();
                 let mut buffer = surface.buffer_mut().expect("Failed to get mutable buffer");
+
+                let fbsize = self.fb.as_pixels().len();
+                if buffer.len() != fbsize {
+                    warn!(
+                        "window buffer has size {}, but fb has size {}! Skipping redraw.",
+                        buffer.len(),
+                        fbsize
+                    );
+                    return;
+                }
 
                 buffer.copy_from_slice(
                     &self


### PR DESCRIPTION
### fix: ignore spurious zero-sized window buffers

winit+x11 usually supplies a single redraw event where the window’s backing buffer is still size zero. ignoring this case stops the event handler thread from panicking.

### fix: use physical size for winit window

physical size is needed since our raw framebuffer work doesn’t care about logical pixels and associated DPI scaling. with logical size, the window is too large (or even too small) for the area that is actually used for the framebuffer.