### PR TITLE
chore: Fix clippy warnings

### DIFF
--- a/breakwater-parser/src/original.rs
+++ b/breakwater-parser/src/original.rs
@@ -155,7 +155,7 @@ impl<FB: FrameBuffer> Parser for OriginalParser<FB> {
                             let g: u32 = (((current >> 16) & 0xff) * alpha_comp + g * alpha) / 0xff;
                             let b: u32 = (((current >> 8) & 0xff) * alpha_comp + b * alpha) / 0xff;
 
-                            self.fb.set(x, y, r << 16 | g << 8 | b);
+                            self.fb.set(x, y, (r << 16) | (g << 8) | b);
                             continue;
                         }
 
@@ -166,7 +166,7 @@ impl<FB: FrameBuffer> Parser for OriginalParser<FB> {
 
                             let base = simd_unhex(unsafe { buffer.as_ptr().add(i - 3) }) & 0xff;
 
-                            let rgba: u32 = base << 16 | base << 8 | base;
+                            let rgba: u32 = (base << 16) | (base << 8) | base;
 
                             self.fb.set(x, y, rgba);
 
@@ -310,13 +310,13 @@ impl<FB: FrameBuffer> Parser for OriginalParser<FB> {
 }
 
 const fn string_to_number(input: &[u8]) -> u64 {
-    (input[7] as u64) << 56
-        | (input[6] as u64) << 48
-        | (input[5] as u64) << 40
-        | (input[4] as u64) << 32
-        | (input[3] as u64) << 24
-        | (input[2] as u64) << 16
-        | (input[1] as u64) << 8
+    ((input[7] as u64) << 56)
+        | ((input[6] as u64) << 48)
+        | ((input[5] as u64) << 40)
+        | ((input[4] as u64) << 32)
+        | ((input[3] as u64) << 24)
+        | ((input[2] as u64) << 16)
+        | ((input[1] as u64) << 8)
         | (input[0] as u64)
 }
 

--- a/breakwater-parser/src/refactored.rs
+++ b/breakwater-parser/src/refactored.rs
@@ -159,7 +159,7 @@ impl<FB: FrameBuffer> RefactoredParser<FB> {
         let g: u32 = (((current >> 16) & 0xff) * alpha_comp + g * alpha) / 0xff;
         let b: u32 = (((current >> 8) & 0xff) * alpha_comp + b * alpha) / 0xff;
 
-        self.fb.set(x, y, r << 16 | g << 8 | b);
+        self.fb.set(x, y, (r << 16) | (g << 8) | b);
     }
 
     #[inline(always)]
@@ -168,7 +168,7 @@ impl<FB: FrameBuffer> RefactoredParser<FB> {
         // Or - as an alternative - still do the SIMD part but only load two bytes.
         let base: u32 = simd_unhex(unsafe { buffer.as_ptr().add(idx - 3) }) & 0xff;
 
-        let rgba: u32 = base << 16 | base << 8 | base;
+        let rgba: u32 = (base << 16) | (base << 8) | base;
 
         self.fb.set(x, y, rgba);
     }

--- a/breakwater/src/server.rs
+++ b/breakwater/src/server.rs
@@ -189,15 +189,12 @@ pub async fn handle_connection<FB: FrameBuffer>(
 
     loop {
         // Fill the buffer up with new data from the socket
-        // If there are any bytes left over from the previous loop iteration leave them as is and but the new data behind
-        let bytes_read = match stream
+        // If there are any bytes left over from the previous loop iteration leave them as is and put the new data behind
+        let Ok(bytes_read) = stream
             .read(&mut buffer[leftover_bytes_in_buffer..network_buffer_size - parser_lookahead])
             .await
-        {
-            Ok(bytes_read) => bytes_read,
-            Err(_) => {
-                break;
-            }
+        else {
+            break;
         };
 
         statistics_bytes_read += bytes_read as u64;

--- a/breakwater/src/sinks/vnc.rs
+++ b/breakwater/src/sinks/vnc.rs
@@ -46,7 +46,7 @@ pub enum Error {
 }
 
 // Sorry! Help needed :)
-unsafe impl<'a, FB: FrameBuffer> Send for VncSink<'a, FB> {}
+unsafe impl<FB: FrameBuffer> Send for VncSink<'_, FB> {}
 
 pub struct VncSink<'a, FB: FrameBuffer> {
     fb: Arc<FB>,


### PR DESCRIPTION
Fixes all warnings with clippy `1.85.0-nightly`