### PR TITLE
fix: Fix memory leak for receive buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Receive buffers for pixelflut connections that were leaked before will now be properly deallocated.
+- Errors while allocating receive buffers for pixelflut connections are now handled properly.
+
 ## [0.16.2] - 2024-12-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Receive buffers for pixelflut connections that were leaked before will now be properly deallocated.
-- Errors while allocating receive buffers for pixelflut connections are now handled properly.
+- Receive buffers for pixelflut connections that were leaked before will now be properly deallocated ([#46])
+- Errors while allocating receive buffers for pixelflut connections are now handled properly ([#46])
+
+[#46]: https://github.com/sbernauer/breakwater/pull/46
 
 ## [0.16.2] - 2024-12-30
 

--- a/README.md
+++ b/README.md
@@ -178,15 +178,6 @@ I never used this for a longer time period, so happy about feedback!
 
 # Known issues
 
-## Failed to memadvise sequential read access for buffer to kernel
-
-During high traffic at GPN22 a few warnings where raised as breakwater was not able to memadvise the created buffer to the kernel.
-
-This *should* not happen, as we allocate the memory area directly before but who knows.
-The memadvise is only on a best-effort base, client connections while still be served even if the call fails.
-The worst thing that should happen is a minimal performance degradation.
-Have a look at [the issue report](https://github.com/sbernauer/breakwater/issues/28) for details.
-
 # Performance
 
 ## Laptop

--- a/breakwater/src/connection_buffer.rs
+++ b/breakwater/src/connection_buffer.rs
@@ -1,0 +1,76 @@
+use std::alloc::{self, LayoutError};
+
+use log::warn;
+use memadvise::{Advice, MemAdviseError};
+use snafu::{ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to create memory layout"))]
+    CreateMemoryLayout {
+        source: LayoutError,
+        buffer_size: usize,
+        page_size: usize,
+    },
+
+    #[snafu(display("Allocation failed (alloc::alloc returned null ptr) for layout {layout:?}"))]
+    AllocationFailed { layout: alloc::Layout },
+}
+
+pub struct ConnectionBuffer {
+    ptr: *mut u8,
+    layout: alloc::Layout,
+}
+
+/// Safety:
+/// - `ConnectionBuffer` has exclusive ownership of the memory behind `ptr`
+/// - safe access through `ConnectionBuffer::as_slice_mut()`
+unsafe impl Send for ConnectionBuffer {}
+
+/// Allocates a memory slice with the specified size, which can be used for client connections.
+///
+/// It takes care of de-allocating the memory slice on [`Drop`].
+/// It also `memadvise`s the memory slice, so that the Kernel is aware that we are going to
+/// sequentially read it.
+impl ConnectionBuffer {
+    pub fn new(buffer_size: usize) -> Result<Self, Error> {
+        let page_size = page_size::get();
+        let layout = alloc::Layout::from_size_align(buffer_size, page_size).context(
+            CreateMemoryLayoutSnafu {
+                buffer_size,
+                page_size,
+            },
+        )?;
+
+        let ptr = unsafe { alloc::alloc(layout) };
+
+        if ptr.is_null() {
+            AllocationFailedSnafu { layout }.fail()?;
+        }
+
+        if let Err(err) = memadvise::advise(ptr as _, layout.size(), Advice::Sequential) {
+            // [`MemAdviseError`] does not implement Debug...
+            let err = match err {
+                MemAdviseError::NullAddress => "NullAddress",
+                MemAdviseError::InvalidLength => "InvalidLength",
+                MemAdviseError::UnalignedAddress => "UnalignedAddress",
+                MemAdviseError::InvalidRange => "InvalidRange",
+            };
+            warn!("Failed to memadvise sequential read access for buffer to kernel. This should not effect any client connections, but might having some minor performance degration: {err}");
+        }
+
+        Ok(Self { ptr, layout })
+    }
+
+    pub fn as_slice_mut(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.layout.size()) }
+    }
+}
+
+impl Drop for ConnectionBuffer {
+    fn drop(&mut self) {
+        unsafe {
+            alloc::dealloc(self.ptr, self.layout);
+        }
+    }
+}

--- a/breakwater/src/main.rs
+++ b/breakwater/src/main.rs
@@ -25,6 +25,7 @@ use crate::sinks::native_display::NativeDisplaySink;
 use crate::sinks::vnc::VncSink;
 
 mod cli_args;
+mod connection_buffer;
 mod prometheus_exporter;
 mod server;
 mod sinks;

--- a/breakwater/src/tests.rs
+++ b/breakwater/src/tests.rs
@@ -116,7 +116,6 @@ async fn test_safe<FB: FrameBuffer>(
         fb.clone(),
         statistics_channel.0,
         DEFAULT_NETWORK_BUFFER_SIZE,
-        page_size::get(),
         None,
     )
     .await
@@ -191,7 +190,6 @@ async fn test_drawing_rect<FB: FrameBuffer>(
         Arc::clone(&fb),
         statistics_channel.0.clone(),
         DEFAULT_NETWORK_BUFFER_SIZE,
-        page_size::get(),
         None,
     )
     .await
@@ -206,7 +204,6 @@ async fn test_drawing_rect<FB: FrameBuffer>(
         Arc::clone(&fb),
         statistics_channel.0.clone(),
         DEFAULT_NETWORK_BUFFER_SIZE,
-        page_size::get(),
         None,
     )
     .await
@@ -221,7 +218,6 @@ async fn test_drawing_rect<FB: FrameBuffer>(
         Arc::clone(&fb),
         statistics_channel.0.clone(),
         DEFAULT_NETWORK_BUFFER_SIZE,
-        page_size::get(),
         None,
     )
     .await
@@ -236,7 +232,6 @@ async fn test_drawing_rect<FB: FrameBuffer>(
         Arc::clone(&fb),
         statistics_channel.0.clone(),
         DEFAULT_NETWORK_BUFFER_SIZE,
-        page_size::get(),
         None,
     )
     .await
@@ -278,7 +273,6 @@ async fn test_binary_set_pixel<FB: FrameBuffer>(
         fb,
         statistics_channel.0,
         DEFAULT_NETWORK_BUFFER_SIZE,
-        page_size::get(),
         None,
     )
     .await
@@ -452,7 +446,6 @@ async fn test_binary_sync_pixels_larger_than_buffer<FB: FrameBuffer>(fb: Arc<FB>
         fb,
         statistics_channel().0,
         DEFAULT_NETWORK_BUFFER_SIZE,
-        page_size::get(),
         None,
     )
     .await
@@ -469,7 +462,6 @@ async fn assert_returns(input: &[u8], expected: &str) {
         fb(),
         statistics_channel().0,
         DEFAULT_NETWORK_BUFFER_SIZE,
-        page_size::get(),
         None,
     )
     .await


### PR DESCRIPTION
This PR fixes a memory leak that occurred because we did not deallocate the rx buffers of our connection. This PR introduces a new struct handling the allocation and deallocation.

Closer inspection revealed a potential cause for #28.
`alloc::alloc()` returns a null pointer in case of error. This PR now handles that. [docs](https://doc.rust-lang.org/alloc/alloc/trait.GlobalAlloc.html#errors)
