### PR TITLE
chore: Release 0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.16.3] - 2025-01-11
+
 ### Fixed
 
 - Receive buffers for pixelflut connections that were leaked before will now be properly deallocated ([#46])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "breakwater"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "async-trait",
  "breakwater-parser",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "breakwater-parser"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "const_format",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["breakwater-parser", "breakwater"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.2"
+version = "0.16.3"
 license = "Beerware"
 authors = ["Sebastian Bernauer <bernauerse@web.de>"]
 edition = "2021"
@@ -36,8 +36,8 @@ vncserver = "0.2"
 winit = "0.30"
 
 # Uses the given path when used locally, and uses the specified version from crates.io when published.
-breakwater-core = { path = "breakwater-core", version = "0.16.2" }
-breakwater-parser = { path = "breakwater-parser", version = "0.16.2" }
+breakwater-core = { path = "breakwater-core", version = "0.16.3" }
+breakwater-parser = { path = "breakwater-parser", version = "0.16.3" }
 
 [profile.dev]
 opt-level = 3

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   pixelflut:
-    image: sbernauer/breakwater:0.16.2
+    image: sbernauer/breakwater:0.16.3
     # build: ..
     restart: unless-stopped
     entrypoint:


### PR DESCRIPTION
### Fixed

- Receive buffers for pixelflut connections that were leaked before will now be properly deallocated ([#46])
- Errors while allocating receive buffers for pixelflut connections are now handled properly ([#46])

[#46]: https://github.com/sbernauer/breakwater/pull/46