### PR TITLE
feat: Add egui and eframe for native display and nice ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add a customizable multi-window native display using egui ([#48])
+
 ### Fixed
 
 - Ensure statistic information updates are send periodically ([#49])
 
+[#48]: https://github.com/sbernauer/breakwater/pull/48
 [#49]: https://github.com/sbernauer/breakwater/pull/49
 
 ## [0.16.3] - 2025-01-11

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
+name = "accesskit"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b76d84ee70e30a4a7e39ab9018e2b17a6a09e31084176cc7c0b2dec036ba45"
+dependencies = [
+ "enumn",
+ "serde",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +52,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "getrandom",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -68,7 +79,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "cc",
  "cesu8",
  "jni",
@@ -77,7 +88,7 @@ dependencies = [
  "log",
  "ndk",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror",
 ]
@@ -171,6 +182,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
+name = "arboard"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df099ccb16cd014ff054ac1bf392c67feeef57164b05c42f037cd40f5d4357f4"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "x11rb",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,7 +204,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -206,6 +232,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,7 +248,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -267,12 +302,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -285,9 +326,24 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.89",
  "which",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
 
 [[package]]
 name = "bit_field"
@@ -303,15 +359,24 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitstream-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block2"
@@ -327,11 +392,17 @@ name = "breakwater"
 version = "0.16.3"
 dependencies = [
  "async-trait",
+ "breakwater-egui-overlay",
  "breakwater-parser",
+ "bytemuck",
  "chrono",
  "clap",
  "const_format",
+ "eframe",
+ "egui",
  "env_logger",
+ "libloading",
+ "local-ip-address",
  "log",
  "memadvise",
  "number_prefix",
@@ -347,6 +418,14 @@ dependencies = [
  "tokio",
  "vncserver",
  "winit",
+]
+
+[[package]]
+name = "breakwater-egui-overlay"
+version = "0.16.3"
+dependencies = [
+ "eframe",
+ "egui",
 ]
 
 [[package]]
@@ -380,9 +459,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -395,7 +474,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -422,7 +501,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "log",
  "polling",
  "rustix",
@@ -498,9 +577,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "chrono"
@@ -591,7 +685,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -599,6 +693,25 @@ name = "clap_lex"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
 
 [[package]]
 name = "color_quant"
@@ -611,6 +724,37 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "com"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
+dependencies = [
+ "com_macros",
+]
+
+[[package]]
+name = "com_macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
+dependencies = [
+ "com_macros_support",
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "com_macros_support"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "combine"
@@ -696,7 +840,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "core-foundation 0.10.0",
  "core-graphics-types 0.2.0",
  "foreign-types",
@@ -720,7 +864,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "core-foundation 0.10.0",
  "libc",
 ]
@@ -838,7 +982,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -848,6 +992,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -868,7 +1021,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98888c4bbd601524c11a7ed63f814b8825f420514f78e96f752c437ae9cbb5d1"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "bytemuck",
  "drm-ffi",
  "drm-fourcc",
@@ -902,10 +1055,150 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecolor"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775cfde491852059e386c4e1deb4aef381c617dc364184c6f6afee99b87c402b"
+dependencies = [
+ "bytemuck",
+ "emath",
+ "serde",
+]
+
+[[package]]
+name = "eframe"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ac2645a9bf4826eb4e91488b1f17b8eaddeef09396706b2f14066461338e24f"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "egui-wgpu",
+ "egui-winit",
+ "egui_glow",
+ "glow 0.14.2",
+ "glutin",
+ "glutin-winit",
+ "home",
+ "image",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "raw-window-handle",
+ "ron",
+ "serde",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "web-time",
+ "winapi 0.3.9",
+ "windows-sys 0.52.0",
+ "winit",
+]
+
+[[package]]
+name = "egui"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53eafabcce0cb2325a59a98736efe0bf060585b437763f8c476957fb274bb974"
+dependencies = [
+ "accesskit",
+ "ahash",
+ "emath",
+ "epaint",
+ "log",
+ "nohash-hasher",
+ "ron",
+ "serde",
+]
+
+[[package]]
+name = "egui-wgpu"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00fd5d06d8405397e64a928fa0ef3934b3c30273ea7603e3dc4627b1f7a1a82"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "epaint",
+ "log",
+ "thiserror",
+ "type-map",
+ "web-time",
+ "wgpu",
+ "winit",
+]
+
+[[package]]
+name = "egui-winit"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9c430f4f816340e8e8c1b20eec274186b1be6bc4c7dfc467ed50d57abc36c6"
+dependencies = [
+ "ahash",
+ "arboard",
+ "egui",
+ "log",
+ "raw-window-handle",
+ "serde",
+ "smithay-clipboard",
+ "web-time",
+ "webbrowser",
+ "winit",
+]
+
+[[package]]
+name = "egui_glow"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e39bccc683cd43adab530d8f21a13eb91e80de10bcc38c3f1c16601b6f62b26"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "egui",
+ "glow 0.14.2",
+ "log",
+ "memoffset",
+ "wasm-bindgen",
+ "web-sys",
+ "winit",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "emath"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1fe0049ce51d0fb414d029e668dd72eb30bc2b739bf34296ed97bd33df544f3"
+dependencies = [
+ "bytemuck",
+ "serde",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
 
 [[package]]
 name = "env_filter"
@@ -931,6 +1224,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "epaint"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a32af8da821bd4f43f2c137e295459ee2e1661d87ca8779dfa0eaf45d870e20f"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "bytemuck",
+ "ecolor",
+ "emath",
+ "epaint_default_fonts",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "serde",
+]
+
+[[package]]
+name = "epaint_default_fonts"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483440db0b7993cf77a20314f08311dbe95675092405518c0677aa08c151a3ea"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +1262,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "exr"
@@ -993,6 +1316,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,7 +1339,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1084,7 +1413,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1161,10 +1490,163 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "glow"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glow"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51fa363f025f5c111e03f13eda21162faeacb6911fe8caa0c0349f9cf0c4483"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec69412a0bf07ea7607e638b415447857a808846c2b685a43c8aa18bc6d5e499"
+dependencies = [
+ "bitflags 2.7.0",
+ "cfg_aliases 0.2.1",
+ "cgl",
+ "core-foundation 0.9.4",
+ "dispatch",
+ "glutin_egl_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "libloading",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "once_cell",
+ "raw-window-handle",
+ "wayland-sys",
+ "windows-sys 0.52.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin-winit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "glutin",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae99fff4d2850dbe6fb8c1fa8e4fead5525bab715beaacfccf3fb994e01c827"
+dependencies = [
+ "gl_generator",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2b2d3918e76e18e08796b55eb64e8fe6ec67d5a6b2e2a7e2edce224ad24c63"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4e1951bbd9434a81aa496fe59ccc2235af3820d27b85f9314e279609211e2c"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+dependencies = [
+ "bitflags 2.7.0",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+dependencies = [
+ "bitflags 2.7.0",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd4240fc91d3433d5e5b0fc5b67672d771850dc19bbee03c1381e19322803d7"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror",
+ "winapi 0.3.9",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf29e94d6d243368b7a56caa16bc213e4f9f8ed38c4d9557069527b5d5281ca"
+dependencies = [
+ "bitflags 2.7.0",
+ "gpu-descriptor-types",
+ "hashbrown",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.7.0",
+]
 
 [[package]]
 name = "half"
@@ -1181,6 +1663,24 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hassle-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
+dependencies = [
+ "bitflags 2.7.0",
+ "com",
+ "libc",
+ "libloading",
+ "thiserror",
+ "widestring",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "heck"
@@ -1199,6 +1699,12 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "home"
@@ -1353,7 +1859,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1434,7 +1940,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1535,6 +2041,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,7 +2107,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "libc",
  "redox_syscall 0.5.7",
 ]
@@ -1606,6 +2129,24 @@ name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
+name = "local-ip-address"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3669cf5561f8d27e8fc84cc15e58350e70f557d4d65f70e3154e54cd2f8e1782"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "lock_api"
@@ -1630,6 +2171,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1670,6 +2220,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.7.0",
+ "block",
+ "core-graphics-types 0.1.3",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,15 +2272,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "naga"
+version = "22.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd5a652b6faf21496f2cfd88fc49989c8db0825d1f6746b1a71a6ede24a63ad"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.7.0",
+ "cfg_aliases 0.1.1",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "rustc-hash",
+ "spirv",
+ "termcolor",
+ "thiserror",
+ "unicode-xid",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror",
@@ -1720,11 +2315,45 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
+name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "neli"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1100229e06604150b3becd61a4965d5c70f3be1759544ea7274166f4be41ef43"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168194d373b1e134786274020dae7fc5513d565ea2ebb9bc9ff17ffb69106d4"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1743,6 +2372,12 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -1793,7 +2428,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1843,7 +2478,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1851,6 +2486,15 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
 
 [[package]]
 name = "objc-sys"
@@ -1874,7 +2518,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "block2",
  "libc",
  "objc2",
@@ -1890,7 +2534,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "block2",
  "objc2",
  "objc2-core-location",
@@ -1914,7 +2558,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -1956,7 +2600,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "block2",
  "dispatch",
  "libc",
@@ -1981,7 +2625,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -1993,7 +2637,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -2016,7 +2660,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -2048,7 +2692,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "block2",
  "objc2",
  "objc2-core-location",
@@ -2175,7 +2819,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2282,13 +2926,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2325,7 +2975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2510,7 +3160,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
 ]
 
 [[package]]
@@ -2549,10 +3199,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
 name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+
+[[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64",
+ "bitflags 2.7.0",
+ "serde",
+ "serde_derive",
+]
 
 [[package]]
 name = "rstest"
@@ -2580,7 +3248,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.89",
  "unicode-ident",
 ]
 
@@ -2611,7 +3279,7 @@ version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -2691,7 +3359,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2764,6 +3432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2775,7 +3452,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -2792,6 +3469,17 @@ dependencies = [
  "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc8216eec463674a0e90f29e0ae41a4db573ec5b56b1c6c1c71615d249b6d846"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit",
+ "wayland-backend",
 ]
 
 [[package]]
@@ -2821,7 +3509,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2842,7 +3530,7 @@ checksum = "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08"
 dependencies = [
  "as-raw-xcb-connection",
  "bytemuck",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "core-graphics 0.24.0",
  "drm",
  "fastrand",
@@ -2867,10 +3555,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "spirv"
+version = "0.3.0+sdk-1.3.268.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.7.0",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strict-num"
@@ -2883,6 +3586,17 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2903,7 +3617,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2941,6 +3655,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,7 +3680,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -3098,7 +3821,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -3164,6 +3887,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5902c5d130972a0000f60860bfbf46f7ca3db5391eddfedd1b8728bd9dc96c0e"
 
 [[package]]
+name = "type-map"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb68604048ff8fa93347f02441e4487594adc20bb8a084f9e564d2b827a0a9f"
+dependencies = [
+ "rustc-hash",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3174,6 +3906,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -3281,7 +4019,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
  "wasm-bindgen-shared",
 ]
 
@@ -3315,7 +4053,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3346,7 +4084,7 @@ version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -3358,7 +4096,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -3380,7 +4118,7 @@ version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd0ade57c4e6e9a8952741325c30bf82f4246885dca8bf561898b86d0c1f58e"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -3392,7 +4130,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b31cab548ee68c7eb155517f2212049dc151f7cd7910c2b66abfd31c3ee12bd"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3405,7 +4143,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "782e12f6cd923c3c316130d56205ebab53f55d6666b7faddfad36cecaeeb4022"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -3456,10 +4194,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea9fe1ebb156110ff855242c1101df158b822487e4957b0556d9ffce9db0f535"
+dependencies = [
+ "block2",
+ "core-foundation 0.10.0",
+ "home",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+
+[[package]]
+name = "wgpu"
+version = "22.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d1c4ba43f80542cf63a0a6ed3134629ae73e8ab51e4b765a67f3aa062eb433"
+dependencies = [
+ "arrayvec",
+ "cfg_aliases 0.1.1",
+ "document-features",
+ "js-sys",
+ "log",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "22.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348c840d1051b8e86c3bcd31206080c5e71e5933dabd79be1ce732b0b2f089a"
+dependencies = [
+ "arrayvec",
+ "bit-vec",
+ "bitflags 2.7.0",
+ "cfg_aliases 0.1.1",
+ "document-features",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6bbf4b4de8b2a83c0401d9e5ae0080a2792055f25859a02bf9be97952bbed4f"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bitflags 2.7.0",
+ "cfg_aliases 0.1.1",
+ "core-graphics-types 0.1.3",
+ "glow 0.13.1",
+ "glutin_wgl_sys",
+ "gpu-alloc",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hassle-rs",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "metal",
+ "naga",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "objc",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "rustc-hash",
+ "smallvec",
+ "thiserror",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9d91f0e2c4b51434dfa6db77846f2793149d8e73f800fa2e41f52b8eac3c5d"
+dependencies = [
+ "bitflags 2.7.0",
+ "js-sys",
+ "web-sys",
+]
 
 [[package]]
 name = "which"
@@ -3472,6 +4329,12 @@ dependencies = [
  "once_cell",
  "rustix",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"
@@ -3749,11 +4612,11 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "block2",
  "bytemuck",
  "calloop",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",
@@ -3857,7 +4720,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.7.0",
  "dlib",
  "log",
  "once_cell",
@@ -3869,6 +4732,12 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
 
 [[package]]
 name = "yoke"
@@ -3890,7 +4759,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
  "synstructure",
 ]
 
@@ -3912,7 +4781,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -3932,7 +4801,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
  "synstructure",
 ]
 
@@ -3955,7 +4824,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.89",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,16 @@ repository = "https://github.com/sernauer/breakwater"
 
 [workspace.dependencies]
 async-trait = "0.1"
+bytemuck = { version = "1.21" }
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 const_format = "0.2"
 criterion = { version = "0.5", features = ["async_tokio"] }
+eframe = { version = "0.29", default-features = false, features = ["glow", "default_fonts", "persistence", "wayland", "x11"] }
+egui = { version = "0.29" }
 env_logger = "0.11"
+libloading = { version = "0.8" }
+local-ip-address = "0.6.3"
 log = "0.4"
 memadvise = "0.1"
 memchr = "2.7"
@@ -30,28 +35,11 @@ serde_json = "1.0"
 simple_moving_average = "1.0"
 snafu = "0.8"
 softbuffer = "0.4"
-tokio = { version = "1.41", features = [
-  "fs",
-  "rt-multi-thread",
-  "net",
-  "io-util",
-  "macros",
-  "process",
-  "signal",
-  "sync",
-  "time",
-] }
+tokio = { version = "1.41", features = ["fs", "rt-multi-thread", "net", "io-util", "macros", "process", "signal", "sync", "time"] }
 trait-variant = "0.1"
 vncserver = "0.2"
 winit = "0.30"
-eframe = { version = "0.29", default-features = false, features = [
-  "glow",
-  "default_fonts",
-  "persistence",
-  "wayland",
-  "x11",
-] }
-egui = { version = "0.29" }
+
 
 # Uses the given path when used locally, and uses the specified version from crates.io when published.
 breakwater-core = { path = "breakwater-core", version = "0.16.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["breakwater-parser", "breakwater"]
+members = ["breakwater-parser", "breakwater", "breakwater-egui-overlay"]
 resolver = "2"
 
 [workspace.package]
@@ -14,7 +14,7 @@ async-trait = "0.1"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 const_format = "0.2"
-criterion = {version = "0.5", features = ["async_tokio"]}
+criterion = { version = "0.5", features = ["async_tokio"] }
 env_logger = "0.11"
 log = "0.4"
 memadvise = "0.1"
@@ -30,14 +30,33 @@ serde_json = "1.0"
 simple_moving_average = "1.0"
 snafu = "0.8"
 softbuffer = "0.4"
-tokio = { version = "1.41", features = ["fs", "rt-multi-thread", "net", "io-util", "macros", "process", "signal", "sync", "time"] }
+tokio = { version = "1.41", features = [
+  "fs",
+  "rt-multi-thread",
+  "net",
+  "io-util",
+  "macros",
+  "process",
+  "signal",
+  "sync",
+  "time",
+] }
 trait-variant = "0.1"
 vncserver = "0.2"
 winit = "0.30"
+eframe = { version = "0.29", default-features = false, features = [
+  "glow",
+  "default_fonts",
+  "persistence",
+  "wayland",
+  "x11",
+] }
+egui = { version = "0.29" }
 
 # Uses the given path when used locally, and uses the specified version from crates.io when published.
 breakwater-core = { path = "breakwater-core", version = "0.16.3" }
 breakwater-parser = { path = "breakwater-parser", version = "0.16.3" }
+breakwater-egui-overlay = { path = "breakwater-egui-overlay", version = "0.16.3" }
 
 [profile.dev]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ cargo run --release -- --help
 cargo run --release -- --help
     Finished release [optimized] target(s) in 0.04s
      Running `target/release/breakwater --help`
+Pixelflut server
+
 Usage: breakwater [OPTIONS]
 
 Options:
@@ -93,6 +95,12 @@ Options:
           Port of the VNC server [default: 5900]
       --native-display
           Enable native display output. This requires some form of graphical system (so will probably not work on your server)
+      --viewport <VIEWPORT>
+          Specify a view port to display the canvas or a certain part of it. Format: <offset_x>x<offset_y>,<width>x<height>. Might be specified multiple times for more than one viewport. Useful for multi-projector setups. Defaults to display the entire canvas. Implies --native-display
+      --advertised-endpoints <ADVERTISED_ENDPOINTS>
+          Specify one or more pixelflut endpoints to display
+      --ui <UI>
+          Provide a path to a dylib containing a custom egui overlay
   -h, --help
           Print help
   -V, --version
@@ -119,6 +127,10 @@ To e.g. turn the VNC server off, build with
 ```bash
 cargo run --release --no-default-features # --features alpha,vnc to explicitly enable
 ```
+
+## Custom overlay for the egui native display
+
+See this [guide](docs/custom-overlay.md).
 
 ## Usage of SIMD and nightly Rust
 [Fabian Wunsch](https://github.com/fabi321) has introduced initial support for SIMD when parsing the hexadecimal color values in [#5](https://github.com/sbernauer/breakwater/pull/5). Thanks!

--- a/README.md
+++ b/README.md
@@ -116,10 +116,11 @@ Breakwater also has some compile-time features for dependency or performance rea
 You can get the list of available features by looking at the [Cargo.toml](Cargo.toml).
 As of writing the following features are supported:
 
-* `native-display` (enabled by default): Starts a graphical window on your local system. Please note that this requires a graphical environment.
+* `egui` (enabled by default): Enables an advanced customizable graphical frontend on your local system. Please note that this requires a graphical environment.
+* `native-display` (disabled by default): Enables a minimalist graphical window on your local system. Please note that this requires a graphical environment.
 * `vnc` (enabled by default): Starts a VNC server, where users can connect to. Needs `libvncserver-dev` to be installed. Please note that the VNC server offers basically no latency, but consumes quite some CPU.
 * `alpha` (disabled by default): Respect alpha values during `PX` commands. Disabled by default as this can cause performance degradation.
-* `binary-set-pixel` (enabled by default): Allows use of the `PB` command.
+* `binary-set-pixel` (disabled by default): Allows use of the `PB` command.
 * `binary-sync-pixels`(disabled by default): Allows use of the `PXMULTI` command.
 
 To e.g. turn the VNC server off, build with

--- a/breakwater-egui-overlay/Cargo.toml
+++ b/breakwater-egui-overlay/Cargo.toml
@@ -7,5 +7,5 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-egui = { workspace = true, features = [] }
 eframe = { workspace = true, features = [] }
+egui = { workspace = true, features = [] }

--- a/breakwater-egui-overlay/Cargo.toml
+++ b/breakwater-egui-overlay/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "breakwater-egui-overlay"
+version.workspace = true
+license.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+
+[dependencies]
+egui = { workspace = true, features = [] }
+eframe = { workspace = true, features = [] }

--- a/breakwater-egui-overlay/build.rs
+++ b/breakwater-egui-overlay/build.rs
@@ -1,0 +1,20 @@
+use std::{io::Write, path::PathBuf, process::Command};
+
+fn main() {
+    let rustc = std::env::var("RUSTC").unwrap();
+    let rustc_version = String::from_utf8(
+        Command::new(rustc)
+            .arg("--version")
+            .output()
+            .expect("unable to run rustc")
+            .stdout,
+    )
+    .unwrap();
+
+    let out_path = PathBuf::from(std::env::var("OUT_DIR").expect("`OUT_DIR` is not set"));
+
+    std::fs::File::create(out_path.join("RUSTC_VERSION.txt"))
+        .unwrap()
+        .write_all(rustc_version.as_bytes())
+        .unwrap();
+}

--- a/breakwater-egui-overlay/src/lib.rs
+++ b/breakwater-egui-overlay/src/lib.rs
@@ -1,0 +1,207 @@
+pub use eframe;
+pub use egui;
+
+use egui::Margin;
+
+const RUSTC_VERSION: *const std::ffi::c_char = concat!(
+    include_str!(concat!(env!("OUT_DIR"), "/RUSTC_VERSION.txt")),
+    "\0"
+)
+.as_ptr() as _;
+const BREAKWATER_VERSION: *const std::ffi::c_char =
+    concat!(env!("CARGO_PKG_VERSION"), "\0").as_ptr() as _;
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct Versions {
+    pub rustc: *const std::ffi::c_char,
+    pub breakwater: *const std::ffi::c_char,
+}
+
+impl std::fmt::Debug for Versions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use std::ffi::CStr;
+
+        #[derive(Debug)]
+        #[allow(dead_code)]
+        struct Versions<'a> {
+            rustc: &'a CStr,
+            breakwater: &'a CStr,
+        }
+
+        unsafe {
+            Versions {
+                rustc: CStr::from_ptr(self.rustc),
+                breakwater: CStr::from_ptr(self.breakwater),
+            }
+            .fmt(f)
+        }
+    }
+}
+
+pub const VERSIONS: Versions = Versions {
+    rustc: RUSTC_VERSION,
+    breakwater: BREAKWATER_VERSION,
+};
+
+impl PartialEq for Versions {
+    fn eq(&self, other: &Self) -> bool {
+        use std::ffi::CStr;
+
+        unsafe {
+            CStr::from_ptr(self.rustc).eq(CStr::from_ptr(other.rustc))
+                && CStr::from_ptr(self.breakwater).eq(CStr::from_ptr(other.breakwater))
+        }
+    }
+}
+
+pub type New = extern "C" fn(*mut std::ffi::c_void);
+pub type Drop = extern "C" fn(*mut std::ffi::c_void);
+#[allow(improper_ctypes_definitions)] // only called from rust
+pub type DrawUi = extern "C" fn(
+    data: *mut std::ffi::c_void,
+    viewport_idx: u32,
+    ctx: &egui::Context,
+    advertised_endpoints: &[String],
+    connections: u32,
+    ips: u32,
+    legacy_ips: u32,
+    bytes_per_s: u64,
+);
+
+#[repr(C)]
+pub struct DynamicOverlay {
+    pub data: *mut std::ffi::c_void,
+    pub new: *const New,
+    pub draw_ui: DrawUi,
+    pub drop: *const Drop,
+}
+
+// 38c3 colors
+#[allow(dead_code)]
+mod colors {
+    use egui::Color32;
+
+    pub const COLOR_PRIMARY: Color32 = Color32::from_rgb(0xFF, 0x50, 0x53);
+    pub const COLOR_HIGHLIGHT: Color32 = Color32::from_rgb(0xFE, 0xF2, 0xFF);
+    pub const COLOR_ACCENT_A: Color32 = Color32::from_rgb(0xB2, 0xAA, 0xFF);
+    pub const COLOR_ACCENT_B: Color32 = Color32::from_rgb(0x6A, 0x5F, 0xDB);
+    pub const COLOR_ACCENT_C: Color32 = Color32::from_rgb(0x29, 0x11, 0x4C);
+    pub const COLOR_ACCENT_D: Color32 = Color32::from_rgb(0x26, 0x1A, 0x66);
+    pub const COLOR_ACCENT_E: Color32 = Color32::from_rgb(0x19, 0x0B, 0x2F);
+    pub const COLOR_BACKGROUND: Color32 = Color32::from_rgb(0x0F, 0x00, 0x0A);
+}
+
+pub const DEFAULT_OVERLAY: DynamicOverlay = DynamicOverlay {
+    data: std::ptr::null_mut(),
+    new: std::ptr::null(),
+    draw_ui: draw_ui as _,
+    drop: std::ptr::null(),
+};
+
+#[allow(improper_ctypes_definitions)]
+extern "C" fn draw_ui(
+    _: *mut std::ffi::c_void,
+    viewport_idx: u32,
+    ctx: &egui::Context,
+    advertised_endpoints: &[String],
+    connections: u32,
+    ips: u32,
+    legacy_ips: u32,
+    bytes_per_s: u64,
+) {
+    use colors::*;
+
+    // only display on first viewport
+    if viewport_idx > 0 {
+        return;
+    }
+
+    let stats_frame = egui::Frame {
+        fill: COLOR_BACKGROUND.gamma_multiply(0.7),
+        stroke: egui::Stroke::new(1.0, COLOR_PRIMARY),
+        rounding: egui::Rounding::same(10.0),
+        shadow: eframe::epaint::Shadow::default(),
+        inner_margin: Margin::same(12.0),
+        outer_margin: Margin::same(12.0),
+    };
+
+    egui::Area::new(egui::Id::new("overlay_area"))
+        .movable(true)
+        .fixed_pos(egui::pos2(20.0, 20.0)) // Initial position on the screen
+        .show(ctx, |ui| {
+            stats_frame.show(ui, |ui| {
+                ui.label(
+                    egui::RichText::new("breakwater | Pixelflut")
+                        .size(48.0)
+                        .color(COLOR_HIGHLIGHT),
+                );
+                ui.separator();
+
+                egui::Grid::new(egui::Id::new("stats_header_grid")).show(ui, |ui| {
+                    for ep in advertised_endpoints {
+                        ui.label(
+                            egui::RichText::new(ep)
+                                .color(COLOR_HIGHLIGHT)
+                                .size(32.0)
+                                .strong(),
+                        );
+                        ui.end_row();
+                    }
+                });
+
+                ui.separator();
+                egui::Grid::new(egui::Id::new("stats_metrics_grid")).show(ui, |ui| {
+                    ui.label(
+                        egui::RichText::new("Connections: ")
+                            .color(COLOR_HIGHLIGHT)
+                            .size(24.0),
+                    );
+                    ui.label(
+                        egui::RichText::new(format!("{}", connections))
+                            .color(COLOR_HIGHLIGHT)
+                            .size(24.0)
+                            .strong(),
+                    );
+                    ui.label(
+                        egui::RichText::new("IPv6: ")
+                            .color(COLOR_HIGHLIGHT)
+                            .size(24.0),
+                    );
+                    ui.label(
+                        egui::RichText::new(format!("{}", ips))
+                            .color(COLOR_HIGHLIGHT)
+                            .size(24.0)
+                            .strong(),
+                    );
+                    ui.end_row();
+                    ui.label(
+                        egui::RichText::new("RX: ")
+                            .color(COLOR_HIGHLIGHT)
+                            .size(24.0),
+                    );
+                    ui.label(
+                        egui::RichText::new(format!(
+                            "{:.2} GBit/s       ",
+                            (bytes_per_s * 8) as f32 / 1024.0 / 1024.0 / 1024.0
+                        ))
+                        .color(COLOR_HIGHLIGHT)
+                        .size(24.0)
+                        .strong(),
+                    );
+                    ui.label(
+                        egui::RichText::new("IPv4: ")
+                            .color(COLOR_HIGHLIGHT)
+                            .size(24.0),
+                    );
+                    ui.label(
+                        egui::RichText::new(format!("{}", legacy_ips))
+                            .color(COLOR_HIGHLIGHT)
+                            .size(24.0)
+                            .strong(),
+                    );
+                    ui.end_row();
+                });
+            });
+        });
+}

--- a/breakwater-egui-overlay/src/lib.rs
+++ b/breakwater-egui-overlay/src/lib.rs
@@ -3,11 +3,13 @@ pub use egui;
 
 use egui::Margin;
 
+/// rustc version that compiled this crate
 const RUSTC_VERSION: *const std::ffi::c_char = concat!(
     include_str!(concat!(env!("OUT_DIR"), "/RUSTC_VERSION.txt")),
     "\0"
 )
 .as_ptr() as _;
+
 const BREAKWATER_VERSION: *const std::ffi::c_char =
     concat!(env!("CARGO_PKG_VERSION"), "\0").as_ptr() as _;
 
@@ -77,7 +79,7 @@ pub struct DynamicOverlay {
     pub drop: *const Drop,
 }
 
-// 38c3 colors
+/// 38c3 colors
 #[allow(dead_code)]
 mod colors {
     use egui::Color32;

--- a/breakwater-egui-overlay/src/lib.rs
+++ b/breakwater-egui-overlay/src/lib.rs
@@ -4,6 +4,10 @@ pub use egui;
 use egui::Margin;
 
 /// rustc version that compiled this crate
+//
+// Currently it's not supported to read the rust version from a cargo env,
+// so we need to gather it ourselves.
+// See https://github.com/rust-lang/cargo/issues/4408 for details
 const RUSTC_VERSION: *const std::ffi::c_char = concat!(
     include_str!(concat!(env!("OUT_DIR"), "/RUSTC_VERSION.txt")),
     "\0"

--- a/breakwater-parser/Cargo.toml
+++ b/breakwater-parser/Cargo.toml
@@ -25,4 +25,4 @@ alpha = []
 binary-set-pixel = []
 binary-sync-pixels = []
 
-default = ["binary-set-pixel"]
+default = []

--- a/breakwater/Cargo.toml
+++ b/breakwater/Cargo.toml
@@ -13,12 +13,18 @@ path = "src/main.rs"
 
 [dependencies]
 breakwater-parser.workspace = true
+breakwater-egui-overlay = { workspace = true, optional = true }
 
 async-trait.workspace = true
+bytemuck = { workspace = true, optional = true }
 chrono.workspace = true
 clap.workspace = true
 const_format.workspace = true
+eframe = { workspace = true, optional = true }
+egui = { workspace = true, optional = true }
 env_logger.workspace = true
+libloading = { workspace = true, optional = true }
+local-ip-address.workspace = true
 log.workspace = true
 memadvise.workspace = true
 number_prefix.workspace = true
@@ -33,23 +39,17 @@ softbuffer = { workspace = true, optional = true }
 tokio.workspace = true
 vncserver = { workspace = true, optional = true }
 winit = { workspace = true, optional = true }
-eframe = { workspace = true, optional = true }
-egui = { workspace = true, optional = true }
-breakwater-egui-overlay = { workspace = true, optional = true}
-bytemuck = { version = "1.21", optional = true }
-local-ip-address = "0.6.3"
-libloading = { version = "0.8", optional = true }
 
 [dev-dependencies]
 rstest.workspace = true
 
 [features]
-# We don't enable binary-sync-pixels by default to make it a bit harder for clients ;)
-default = ["vnc", "egui"]
+# We don't enable binary-sync-pixels and binary-set-pixel by default to make it a bit harder for clients ;)
+default = ["egui", "vnc"]
 
-vnc = ["dep:vncserver"]
 alpha = ["breakwater-parser/alpha"]
-egui = ["dep:eframe", "dep:egui", "dep:breakwater-egui-overlay", "dep:bytemuck", "dep:libloading"]
-native-display = ["dep:softbuffer", "dep:winit"]
 binary-set-pixel = ["breakwater-parser/binary-set-pixel"]
 binary-sync-pixels = ["breakwater-parser/binary-sync-pixels"]
+egui = ["dep:breakwater-egui-overlay", "dep:bytemuck", "dep:eframe", "dep:egui", "dep:libloading"]
+native-display = ["dep:softbuffer", "dep:winit"]
+vnc = ["dep:vncserver"]

--- a/breakwater/Cargo.toml
+++ b/breakwater/Cargo.toml
@@ -33,16 +33,23 @@ softbuffer = { workspace = true, optional = true }
 tokio.workspace = true
 vncserver = { workspace = true, optional = true }
 winit = { workspace = true, optional = true }
+eframe = { workspace = true, optional = true }
+egui = { workspace = true, optional = true }
+breakwater-egui-overlay = { workspace = true, optional = true}
+bytemuck = { version = "1.21", optional = true }
+local-ip-address = "0.6.3"
+libloading = { version = "0.8", optional = true }
 
 [dev-dependencies]
 rstest.workspace = true
 
 [features]
 # We don't enable binary-sync-pixels by default to make it a bit harder for clients ;)
-default = ["vnc", "native-display", "binary-set-pixel"]
+default = ["vnc", "egui"]
 
 vnc = ["dep:vncserver"]
 alpha = ["breakwater-parser/alpha"]
+egui = ["dep:eframe", "dep:egui", "dep:breakwater-egui-overlay", "dep:bytemuck", "dep:libloading"]
 native-display = ["dep:softbuffer", "dep:winit"]
 binary-set-pixel = ["breakwater-parser/binary-set-pixel"]
 binary-sync-pixels = ["breakwater-parser/binary-sync-pixels"]

--- a/breakwater/src/cli_args.rs
+++ b/breakwater/src/cli_args.rs
@@ -81,7 +81,25 @@ pub struct CliArgs {
 
     /// Enable native display output. This requires some form of graphical system (so will probably not work on your
     /// server).
-    #[cfg(feature = "native-display")]
+    #[cfg(any(feature = "native-display", feature = "egui"))]
     #[clap(long)]
     pub native_display: bool,
+
+    /// Specify a view port to display the canvas or a certain part of it. Format: <offset_x>x<offset_y>,<width>x<height>.
+    /// Might be specified multiple times for more than one viewport. Useful for multi-projector setups.
+    /// Defaults to display the entire canvas.
+    /// Implies --native-display.
+    #[cfg(feature = "egui")]
+    #[clap(long)]
+    pub viewport: Vec<crate::sinks::egui::ViewportConfig>,
+
+    /// Specify one or more pixelflut endpoints to display.
+    #[cfg(feature = "egui")]
+    #[clap(long)]
+    pub advertised_endpoints: Vec<String>,
+
+    /// Provide a path to a dylib containing a custom egui overlay.
+    #[cfg(feature = "egui")]
+    #[clap(long)]
+    pub ui: Option<std::path::PathBuf>,
 }

--- a/breakwater/src/cli_args.rs
+++ b/breakwater/src/cli_args.rs
@@ -99,6 +99,7 @@ pub struct CliArgs {
     pub advertised_endpoints: Vec<String>,
 
     /// Provide a path to a dylib containing a custom egui overlay.
+    /// Implies --native-display.
     #[cfg(feature = "egui")]
     #[clap(long)]
     pub ui: Option<std::path::PathBuf>,

--- a/breakwater/src/cli_args.rs
+++ b/breakwater/src/cli_args.rs
@@ -85,7 +85,7 @@ pub struct CliArgs {
     #[clap(long)]
     pub native_display: bool,
 
-    /// Specify a view port to display the canvas or a certain part of it. Format: <offset_x>x<offset_y>,<width>x<height>.
+    /// Specify a view port to display the canvas or a certain part of it. Format: `<offset_x>x<offset_y>,<width>x<height>`.
     /// Might be specified multiple times for more than one viewport. Useful for multi-projector setups.
     /// Defaults to display the entire canvas.
     /// Implies --native-display.

--- a/breakwater/src/main.rs
+++ b/breakwater/src/main.rs
@@ -200,7 +200,7 @@ async fn main() -> Result<(), Error> {
         {
             tokio::spawn(handle_ctrl_c(terminate_signal_tx));
 
-            // Some plattforms require opening windows from the main thread.
+            // Some platforms require opening windows from the main thread.
             // The tokio::main macro uses Runtime::block_on(future) which runs the future on
             // the current thread, which should be the main thread right now.
             egui_sink.run().await.context(RunSinkSnafu)?;

--- a/breakwater/src/sinks/egui/canvas.frag
+++ b/breakwater/src/sinks/egui/canvas.frag
@@ -1,0 +1,11 @@
+#version 300 es
+precision mediump float;
+
+in vec2 v_tex_coords;
+out vec4 color;
+
+uniform sampler2D canvas_texture;
+
+void main() {
+    color = texture(canvas_texture, v_tex_coords);
+}

--- a/breakwater/src/sinks/egui/canvas.vert
+++ b/breakwater/src/sinks/egui/canvas.vert
@@ -1,0 +1,11 @@
+#version 300 es
+
+layout(location = 0) in vec2 position;
+layout(location = 1) in vec2 tex_coords;
+
+out vec2 v_tex_coords;
+
+void main() {
+    gl_Position = vec4(position, 0.0, 1.0);
+    v_tex_coords = tex_coords;
+}

--- a/breakwater/src/sinks/egui/canvas_renderer.rs
+++ b/breakwater/src/sinks/egui/canvas_renderer.rs
@@ -1,0 +1,226 @@
+use std::{num::NonZero, sync::Arc};
+
+use breakwater_parser::FrameBuffer;
+use eframe::glow::{self, HasContext};
+
+const VERTEX: Vertex = Vertex {
+    position: [0.0; 2],
+    tex_coords: [0.0; 2],
+};
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Vertex {
+    pub position: [f32; 2],
+    pub tex_coords: [f32; 2],
+}
+
+#[derive(Debug)]
+pub struct CanvasRenderer<FB: FrameBuffer> {
+    framebuffer: Arc<FB>,
+    vertex_array: glow::VertexArray,
+    vertex_buffer: glow::Buffer,
+    canvas_texture: glow::Texture,
+    canvas_shaders: glow::Program,
+}
+
+impl<FB: FrameBuffer> CanvasRenderer<FB> {
+    pub fn new(
+        gl: &eframe::glow::Context,
+        framebuffer: Arc<FB>,
+        view_ports: NonZero<usize>,
+    ) -> Self {
+        let (vertex_array, vertex_buffer) = unsafe { init_vertex_data(gl, view_ports.get()) };
+        let canvas_texture = unsafe {
+            init_canvas_texture(
+                gl,
+                framebuffer.get_width() as i32,
+                framebuffer.get_height() as i32,
+            )
+        };
+        let canvas_shaders = unsafe { init_shaders(gl) };
+
+        Self {
+            framebuffer,
+            vertex_array,
+            vertex_buffer,
+            canvas_texture,
+            canvas_shaders,
+        }
+    }
+
+    pub fn prepare(
+        &self,
+        gl: &glow::Context,
+        view_port_index: usize,
+        new_vertices: Option<[Vertex; 4]>,
+    ) {
+        if view_port_index == 0 {
+            unsafe {
+                gl.bind_texture(glow::TEXTURE_2D, Some(self.canvas_texture));
+
+                gl.tex_sub_image_2d(
+                    glow::TEXTURE_2D,
+                    0,
+                    0,
+                    0,
+                    self.framebuffer.get_width() as i32,
+                    self.framebuffer.get_height() as i32,
+                    glow::RGBA,
+                    glow::UNSIGNED_BYTE,
+                    glow::PixelUnpackData::Slice(self.framebuffer.as_bytes()),
+                );
+
+                gl.bind_texture(glow::TEXTURE_2D, None);
+            }
+        }
+
+        if let Some(new_vertices) = new_vertices {
+            unsafe {
+                gl.bind_buffer(glow::ARRAY_BUFFER, Some(self.vertex_buffer));
+                gl.buffer_sub_data_u8_slice(
+                    glow::ARRAY_BUFFER,
+                    (std::mem::size_of::<Vertex>() * 4 * view_port_index) as i32,
+                    bytemuck::cast_slice(&new_vertices),
+                );
+            }
+        }
+    }
+
+    pub fn paint(&self, gl: &glow::Context, view_port_index: usize) {
+        unsafe {
+            gl.clear_color(0.0, 0.0, 0.0, 1.0);
+            gl.clear(glow::COLOR_BUFFER_BIT);
+            gl.use_program(Some(self.canvas_shaders));
+
+            gl.active_texture(glow::TEXTURE0);
+            gl.bind_texture(glow::TEXTURE_2D, Some(self.canvas_texture));
+            let texture_location = gl.get_uniform_location(self.canvas_shaders, "canvas_texture");
+            gl.uniform_1_i32(texture_location.as_ref(), 0);
+
+            gl.bind_vertex_array(Some(self.vertex_array));
+
+            let offset = (4 * view_port_index) as i32;
+            gl.draw_arrays(glow::TRIANGLE_STRIP, offset, 4);
+
+            gl.bind_vertex_array(None);
+            gl.bind_texture(glow::TEXTURE_2D, None);
+            gl.use_program(None);
+        }
+    }
+}
+
+unsafe fn init_vertex_data(
+    gl: &glow::Context,
+    view_port_count: usize,
+) -> (glow::VertexArray, glow::Buffer) {
+    let vao = gl.create_vertex_array().unwrap();
+    gl.bind_vertex_array(Some(vao));
+
+    let vbo = gl.create_buffer().unwrap();
+    gl.bind_buffer(glow::ARRAY_BUFFER, Some(vbo));
+    gl.buffer_data_size(
+        glow::ARRAY_BUFFER,
+        (std::mem::size_of::<Vertex>() * 4 * view_port_count) as i32,
+        glow::STATIC_DRAW,
+    );
+
+    gl.enable_vertex_attrib_array(0);
+    gl.vertex_attrib_pointer_f32(
+        0,
+        2,
+        glow::FLOAT,
+        false,
+        std::mem::size_of_val(&VERTEX) as i32,
+        0,
+    );
+    gl.enable_vertex_attrib_array(1);
+    gl.vertex_attrib_pointer_f32(
+        1,
+        2,
+        glow::FLOAT,
+        false,
+        std::mem::size_of_val(&VERTEX) as i32,
+        std::mem::size_of_val(&VERTEX.position) as i32,
+    );
+
+    // Unbind for safety
+    gl.bind_vertex_array(None);
+
+    (vao, vbo)
+}
+
+unsafe fn init_canvas_texture(gl: &glow::Context, width: i32, height: i32) -> glow::Texture {
+    let texture = gl.create_texture().unwrap();
+    gl.bind_texture(glow::TEXTURE_2D, Some(texture));
+
+    gl.tex_image_2d(
+        glow::TEXTURE_2D,
+        0,
+        glow::RGBA as i32,
+        width,
+        height,
+        0,
+        glow::RGBA,
+        glow::UNSIGNED_BYTE,
+        None,
+    );
+
+    // Set texture parameters
+    gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_WRAP_S, glow::REPEAT as i32);
+    gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_WRAP_T, glow::REPEAT as i32);
+    gl.tex_parameter_i32(
+        glow::TEXTURE_2D,
+        glow::TEXTURE_MIN_FILTER,
+        glow::LINEAR as i32,
+    );
+    gl.tex_parameter_i32(
+        glow::TEXTURE_2D,
+        glow::TEXTURE_MAG_FILTER,
+        glow::LINEAR as i32,
+    );
+    gl.bind_texture(glow::TEXTURE_2D, None);
+
+    texture
+}
+
+unsafe fn init_shaders(gl: &glow::Context) -> glow::Program {
+    let vertex_shader = gl.create_shader(glow::VERTEX_SHADER).unwrap();
+    gl.shader_source(vertex_shader, include_str!("./canvas.vert"));
+    gl.compile_shader(vertex_shader);
+
+    if !gl.get_shader_compile_status(vertex_shader) {
+        panic!(
+            "vertex_shader compilation failed: {}",
+            gl.get_shader_info_log(vertex_shader)
+        );
+    }
+
+    let fragment_shader = gl.create_shader(glow::FRAGMENT_SHADER).unwrap();
+    gl.shader_source(fragment_shader, include_str!("./canvas.frag"));
+    gl.compile_shader(fragment_shader);
+
+    if !gl.get_shader_compile_status(fragment_shader) {
+        panic!(
+            "fragment_shader compilation failed: {}",
+            gl.get_shader_info_log(fragment_shader)
+        );
+    }
+
+    let program = gl.create_program().unwrap();
+    gl.attach_shader(program, vertex_shader);
+    gl.attach_shader(program, fragment_shader);
+    gl.link_program(program);
+
+    if !gl.get_program_link_status(program) {
+        panic!(
+            "Shader program linking failed: {}",
+            gl.get_program_info_log(program)
+        );
+    }
+
+    gl.delete_shader(vertex_shader);
+    gl.delete_shader(fragment_shader);
+
+    program
+}

--- a/breakwater/src/sinks/egui/canvas_renderer.rs
+++ b/breakwater/src/sinks/egui/canvas_renderer.rs
@@ -15,6 +15,7 @@ pub struct Vertex {
     pub tex_coords: [f32; 2],
 }
 
+/// Handles opengl related stuff to instruct a gpu to draw the framebuffer into a an egui widget.
 #[derive(Debug)]
 pub struct CanvasRenderer<FB: FrameBuffer> {
     framebuffer: Arc<FB>,
@@ -55,6 +56,11 @@ impl<FB: FrameBuffer> CanvasRenderer<FB> {
         view_port_index: usize,
         new_vertices: Option<[Vertex; 4]>,
     ) {
+        // This function gets called once per frame for every viewport.
+        // We only want to upload the framebuffer to the gpu once per frame,
+        // so we do it on the first viewport only.
+        // This saves bandwidth to the gpu and ensures a consistent pixelflut canvas across
+        // all viewports.
         if view_port_index == 0 {
             unsafe {
                 gl.bind_texture(glow::TEXTURE_2D, Some(self.canvas_texture));
@@ -166,7 +172,6 @@ unsafe fn init_canvas_texture(gl: &glow::Context, width: i32, height: i32) -> gl
         None,
     );
 
-    // Set texture parameters
     gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_WRAP_S, glow::REPEAT as i32);
     gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_WRAP_T, glow::REPEAT as i32);
     gl.tex_parameter_i32(

--- a/breakwater/src/sinks/egui/dynamic_overlay.rs
+++ b/breakwater/src/sinks/egui/dynamic_overlay.rs
@@ -1,0 +1,121 @@
+use std::path::Path;
+
+use breakwater_egui_overlay::{DynamicOverlay, Versions};
+use log::error;
+use snafu::{IntoError, ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("unable to load dynamic library"))]
+    LibLoading { source: libloading::Error },
+
+    #[snafu(display("unable to find symbol in dynamic library"))]
+    Symbol { source: libloading::Error },
+
+    #[snafu(display("version mismatch"))]
+    VersionMismatch,
+}
+
+pub enum UiOverlay {
+    BuiltIn,
+    Dynamic {
+        _lib: libloading::Library,
+        overlay: DynamicOverlay,
+    },
+}
+
+unsafe impl Send for UiOverlay {}
+unsafe impl Sync for UiOverlay {}
+
+impl Default for UiOverlay {
+    fn default() -> Self {
+        Self::BuiltIn
+    }
+}
+
+impl UiOverlay {
+    #[allow(clippy::too_many_arguments)]
+    pub fn draw_ui(
+        &self,
+        viewport_idx: u32,
+        ctx: &egui::Context,
+        advertised_endpoints: &[String],
+        connections: u32,
+        ips: u32,
+        legacy_ips: u32,
+        bytes_per_s: u64,
+    ) {
+        match self {
+            UiOverlay::BuiltIn => {
+                (breakwater_egui_overlay::DEFAULT_OVERLAY.draw_ui)(
+                    breakwater_egui_overlay::DEFAULT_OVERLAY.data,
+                    viewport_idx,
+                    ctx,
+                    advertised_endpoints,
+                    connections,
+                    ips,
+                    legacy_ips,
+                    bytes_per_s,
+                );
+            }
+            UiOverlay::Dynamic { overlay, .. } => {
+                (overlay.draw_ui)(
+                    overlay.data,
+                    viewport_idx,
+                    ctx,
+                    advertised_endpoints,
+                    connections,
+                    ips,
+                    legacy_ips,
+                    bytes_per_s,
+                );
+            }
+        }
+    }
+}
+
+impl Drop for UiOverlay {
+    fn drop(&mut self) {
+        match self {
+            UiOverlay::BuiltIn => {}
+            UiOverlay::Dynamic { overlay, .. } => {
+                if !overlay.drop.is_null() {
+                    unsafe { (*overlay.drop)(overlay.data) }
+                }
+            }
+        }
+    }
+}
+
+pub fn load_and_check(dylib_path: impl AsRef<Path>) -> Result<UiOverlay, Error> {
+    unsafe {
+        let dylib =
+            libloading::Library::new(dylib_path.as_ref().as_os_str()).context(LibLoadingSnafu)?;
+        let dylib_versions: libloading::Symbol<fn() -> Versions> =
+            dylib.get(b"versions").context(SymbolSnafu)?;
+
+        let dylib_versions = dylib_versions();
+
+        if dylib_versions != breakwater_egui_overlay::VERSIONS {
+            error!(
+                "dylib version ({dylib_versions:?}) do not match our version ({:?})",
+                breakwater_egui_overlay::VERSIONS
+            );
+            return Err(VersionMismatchSnafu.into_error(snafu::NoneError));
+        }
+
+        let dylib_new: libloading::Symbol<fn() -> DynamicOverlay> =
+            dylib.get(b"new").context(SymbolSnafu)?;
+
+        let overlay = dylib_new();
+
+        if !overlay.new.is_null() {
+            (*overlay.new)(overlay.data)
+        };
+
+        Ok(UiOverlay::Dynamic {
+            _lib: dylib,
+            overlay,
+        })
+    }
+}

--- a/breakwater/src/sinks/egui/dynamic_overlay.rs
+++ b/breakwater/src/sinks/egui/dynamic_overlay.rs
@@ -24,7 +24,12 @@ pub enum UiOverlay {
     },
 }
 
+/// Safety:
+/// UiOverlay never leaves the main thread but tokio does not know that :-)
 unsafe impl Send for UiOverlay {}
+
+/// Safety:
+/// UiOverlay never leaves the main thread but tokio does not know that :-)
 unsafe impl Sync for UiOverlay {}
 
 impl Default for UiOverlay {
@@ -87,6 +92,7 @@ impl Drop for UiOverlay {
     }
 }
 
+/// loads a dynamic library for a custom overlay and checks its version
 pub fn load_and_check(dylib_path: impl AsRef<Path>) -> Result<UiOverlay, Error> {
     unsafe {
         let dylib =

--- a/breakwater/src/sinks/egui/mod.rs
+++ b/breakwater/src/sinks/egui/mod.rs
@@ -28,9 +28,12 @@ pub enum Error {
     DynamicOverlay { source: dynamic_overlay::Error },
 }
 
+/// Describes the part of the framebuffer that the corresponding viewport will display.
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 pub struct ViewportConfig {
+    /// x offset
     pub x: usize,
+    /// y offset
     pub y: usize,
     pub width: usize,
     pub height: usize,
@@ -96,9 +99,13 @@ impl<FB: FrameBuffer + Send + Sync + 'static> DisplaySink<FB> for EguiSink<FB> {
     where
         Self: Sized,
     {
-        let viewports = match (cli_args.viewport.as_slice(), cli_args.native_display) {
-            (vp, _) if !vp.is_empty() => Vec::from(vp),
-            ([], true) => vec![ViewportConfig {
+        let viewports = match (
+            cli_args.viewport.as_slice(),
+            cli_args.native_display,
+            cli_args.ui.as_ref(),
+        ) {
+            (vp, _, _) if !vp.is_empty() => Vec::from(vp),
+            ([], _, Some(_)) | ([], true, _) => vec![ViewportConfig {
                 x: 0,
                 y: 0,
                 width: fb.get_width(),
@@ -142,6 +149,7 @@ impl<FB: FrameBuffer + Send + Sync + 'static> DisplaySink<FB> for EguiSink<FB> {
         }))
     }
 
+    /// This should only run on the main thread
     async fn run(&mut self) -> Result<(), super::Error> {
         // block_in_place below should only be used in a MultiThread runtime
         assert_eq!(

--- a/breakwater/src/sinks/egui/mod.rs
+++ b/breakwater/src/sinks/egui/mod.rs
@@ -185,7 +185,7 @@ impl<FB: FrameBuffer + Send + Sync + 'static> EguiSink<FB> {
         let ui_overlay = self.ui_overlay.clone();
 
         eframe::run_native(
-            "Breakwater | Pixelflut Server",
+            "Viewport 0 | Breakwater",
             options,
             Box::new(|cc| {
                 let frontend = view::EguiView::new(

--- a/breakwater/src/sinks/egui/mod.rs
+++ b/breakwater/src/sinks/egui/mod.rs
@@ -1,0 +1,198 @@
+use std::{fmt::Display, net::ToSocketAddrs, str::FromStr, sync::Arc};
+
+use async_trait::async_trait;
+use breakwater_parser::FrameBuffer;
+use dynamic_overlay::UiOverlay;
+use log::error;
+use serde::{Deserialize, Serialize};
+use snafu::{ResultExt, Snafu};
+use tokio::sync::{broadcast, mpsc};
+
+use crate::statistics::StatisticsInformationEvent;
+
+use super::DisplaySink;
+
+mod canvas_renderer;
+mod dynamic_overlay;
+mod view;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("eframe started with an unsupported frontend"))]
+    UnsupportedEguiFrontend,
+
+    #[snafu(display("egui failed"))]
+    EguiFailed,
+
+    #[snafu(display("dynamic overlay error"))]
+    DynamicOverlay { source: dynamic_overlay::Error },
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+pub struct ViewportConfig {
+    pub x: usize,
+    pub y: usize,
+    pub width: usize,
+    pub height: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct InvalidViewportConfig;
+impl Display for InvalidViewportConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Invalid view port config")
+    }
+}
+impl std::error::Error for InvalidViewportConfig {}
+
+impl FromStr for ViewportConfig {
+    type Err = InvalidViewportConfig;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Result<Vec<_>, _> = s
+            .split(",")
+            .flat_map(|s| s.split("x"))
+            .map(usize::from_str)
+            .collect();
+
+        match parts {
+            Err(e) => {
+                error!("unable to parse view port config: {e}");
+                Err(InvalidViewportConfig)
+            }
+            Ok(parts) if parts.len() != 4 => {
+                error!("unable to parse view port config: invalid format");
+                Err(InvalidViewportConfig)
+            }
+            Ok(parts) => Ok(Self {
+                x: parts[0],
+                y: parts[1],
+                width: parts[2],
+                height: parts[3],
+            }),
+        }
+    }
+}
+
+pub struct EguiSink<FB: FrameBuffer> {
+    framebuffer: Arc<FB>,
+    viewports: Vec<ViewportConfig>,
+    terminate_rx: broadcast::Receiver<()>,
+    stats_rx: broadcast::Receiver<StatisticsInformationEvent>,
+    advertised_endpoints: Vec<String>,
+    ui_overlay: Arc<UiOverlay>,
+}
+
+#[async_trait]
+impl<FB: FrameBuffer + Send + Sync + 'static> DisplaySink<FB> for EguiSink<FB> {
+    /// This function can return [`None`] in case this sink is not configured (by looking at the `cli_args`).
+    async fn new(
+        fb: Arc<FB>,
+        cli_args: &crate::cli_args::CliArgs,
+        _statistics_tx: mpsc::Sender<crate::statistics::StatisticsEvent>,
+        statistics_information_rx: broadcast::Receiver<StatisticsInformationEvent>,
+        terminate_signal_rx: broadcast::Receiver<()>,
+    ) -> Result<Option<Self>, super::Error>
+    where
+        Self: Sized,
+    {
+        let viewports = match (cli_args.viewport.as_slice(), cli_args.native_display) {
+            (vp, _) if !vp.is_empty() => Vec::from(vp),
+            ([], true) => vec![ViewportConfig {
+                x: 0,
+                y: 0,
+                width: fb.get_width(),
+                height: fb.get_height(),
+            }],
+            _ => return Ok(None),
+        };
+
+        let ui_overlay = Arc::new({
+            if let Some(ui) = cli_args.ui.as_ref() {
+                dynamic_overlay::load_and_check(ui).context(DynamicOverlaySnafu)?
+            } else {
+                UiOverlay::BuiltIn
+            }
+        });
+
+        let mut advertised_endpoints = cli_args.advertised_endpoints.clone();
+        if advertised_endpoints.is_empty() {
+            let port = cli_args
+                .listen_address
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap()
+                .port();
+            if let Ok(local_ip) = local_ip_address::local_ip() {
+                advertised_endpoints.push(format!("{local_ip}:{port}"));
+            }
+            if let Ok(local_ip) = local_ip_address::local_ipv6() {
+                advertised_endpoints.push(format!("[{local_ip}]:{port}"));
+            }
+        }
+
+        Ok(Some(Self {
+            framebuffer: fb,
+            viewports,
+            terminate_rx: terminate_signal_rx,
+            stats_rx: statistics_information_rx,
+            advertised_endpoints,
+            ui_overlay,
+        }))
+    }
+
+    async fn run(&mut self) -> Result<(), super::Error> {
+        // block_in_place below should only be used in a MultiThread runtime
+        assert_eq!(
+            tokio::runtime::Handle::current().runtime_flavor(),
+            tokio::runtime::RuntimeFlavor::MultiThread
+        );
+
+        tokio::task::block_in_place(move || self.run_eframe_display())
+            .map_err(|e| {
+                error!("egui failed: {e:?}");
+                snafu::NoneError
+            })
+            .context(EguiFailedSnafu)?;
+
+        Ok(())
+    }
+}
+
+impl<FB: FrameBuffer + Send + Sync + 'static> EguiSink<FB> {
+    fn run_eframe_display(&self) -> Result<(), eframe::Error> {
+        let options = eframe::NativeOptions {
+            viewport: egui::ViewportBuilder::default(),
+            renderer: eframe::Renderer::Glow,
+            window_builder: Some(Box::new(|builder| builder.with_app_id("breakwater"))),
+            ..Default::default()
+        };
+
+        let terminate = self.terminate_rx.resubscribe();
+        let stats = self.stats_rx.resubscribe();
+        let framebuffer = self.framebuffer.clone();
+        let viewports = self.viewports.clone();
+        let advertised_endpoints = self.advertised_endpoints.clone();
+        let ui_overlay = self.ui_overlay.clone();
+
+        eframe::run_native(
+            "Breakwater | Pixelflut Server",
+            options,
+            Box::new(|cc| {
+                let frontend = view::EguiView::new(
+                    cc,
+                    framebuffer,
+                    viewports,
+                    terminate,
+                    stats,
+                    advertised_endpoints,
+                    ui_overlay,
+                )
+                .expect("unable to create egui frontend");
+
+                Ok(Box::new(frontend))
+            }),
+        )
+    }
+}

--- a/breakwater/src/sinks/egui/view.rs
+++ b/breakwater/src/sinks/egui/view.rs
@@ -88,6 +88,7 @@ impl<FB: FrameBuffer + Send + Sync + 'static> EguiView<FB> {
     }
 }
 
+/// calculates vertices that the canvas keeps its aspect ratio, but is resized to fit onto the given viewport
 fn calc_new_vertices(
     canvas_view_port: &ViewportConfig,
     [pixel_width, pixel_height]: [i32; 2],

--- a/breakwater/src/sinks/egui/view.rs
+++ b/breakwater/src/sinks/egui/view.rs
@@ -1,0 +1,210 @@
+use std::sync::Arc;
+
+use breakwater_parser::FrameBuffer;
+use eframe::egui_glow;
+use snafu::OptionExt;
+use tokio::sync::broadcast;
+
+use crate::statistics::StatisticsInformationEvent;
+
+use super::{
+    canvas_renderer::{CanvasRenderer, Vertex},
+    dynamic_overlay::UiOverlay,
+    ViewportConfig,
+};
+
+pub struct EguiView<FB: FrameBuffer> {
+    framebuffer: Arc<FB>,
+    canvas_renderer: Arc<CanvasRenderer<FB>>,
+    viewports: Vec<ViewportConfig>,
+    terminate_rx: broadcast::Receiver<()>,
+    stats_rx: broadcast::Receiver<StatisticsInformationEvent>,
+    advertised_endpoints: Vec<String>,
+
+    ui: Arc<UiOverlay>,
+    latest_stats: StatisticsInformationEvent,
+}
+
+impl<FB: FrameBuffer + Send + Sync + 'static> EguiView<FB> {
+    pub fn new<'a>(
+        cc: &'a eframe::CreationContext<'a>,
+        framebuffer: Arc<FB>,
+        viewports: Vec<ViewportConfig>,
+        terminate_rx: broadcast::Receiver<()>,
+        stats_rx: broadcast::Receiver<StatisticsInformationEvent>,
+        advertised_endpoints: Vec<String>,
+        ui: Arc<UiOverlay>,
+    ) -> Result<Self, super::Error> {
+        let gl_context = cc
+            .gl
+            .as_ref()
+            .context(super::UnsupportedEguiFrontendSnafu)?;
+
+        let canvas_renderer = CanvasRenderer::new(
+            gl_context,
+            framebuffer.clone(),
+            viewports.len().try_into().expect("at least one viewport"),
+        );
+        let canvas_renderer = Arc::new(canvas_renderer);
+
+        Ok(Self {
+            latest_stats: StatisticsInformationEvent::default(),
+            ui,
+
+            framebuffer,
+            viewports,
+            canvas_renderer,
+            terminate_rx,
+            stats_rx,
+            advertised_endpoints,
+        })
+    }
+
+    fn draw_canvas(&self, ctx: &egui::Context, view_port_index: usize, view_port: ViewportConfig) {
+        let rect = ctx.screen_rect();
+        let painter = ctx.layer_painter(egui::LayerId::background());
+
+        let canvas_renderer = self.canvas_renderer.clone();
+        let framebuffer = self.framebuffer.clone();
+
+        let callback = egui::PaintCallback {
+            rect,
+            callback: std::sync::Arc::new(egui_glow::CallbackFn::new(move |info, painter| {
+                let new_vertices = calc_new_vertices(
+                    &view_port,
+                    [
+                        info.viewport_in_pixels().width_px,
+                        info.viewport_in_pixels().height_px,
+                    ],
+                    [framebuffer.get_width(), framebuffer.get_height()],
+                );
+
+                canvas_renderer.prepare(painter.gl(), view_port_index, Some(new_vertices));
+                canvas_renderer.paint(painter.gl(), view_port_index);
+            })),
+        };
+
+        painter.add(callback);
+    }
+}
+
+fn calc_new_vertices(
+    canvas_view_port: &ViewportConfig,
+    [pixel_width, pixel_height]: [i32; 2],
+    [canvas_width, canvas_height]: [usize; 2],
+) -> [Vertex; 4] {
+    let mut a = 1f32;
+    let mut b = 1f32;
+
+    if pixel_width as f32 / pixel_height as f32
+        > canvas_view_port.width as f32 / canvas_view_port.height as f32
+    {
+        a = (pixel_height as f32 / pixel_width as f32)
+            * (canvas_view_port.width as f32 / canvas_view_port.height as f32);
+    } else {
+        b = (pixel_width as f32 / pixel_height as f32)
+            * (canvas_view_port.height as f32 / canvas_view_port.width as f32);
+    }
+
+    let u = canvas_view_port.x as f32 / canvas_width as f32;
+    let uu = canvas_view_port.width as f32 / canvas_width as f32;
+    let v = canvas_view_port.y as f32 / canvas_height as f32;
+    let vv = canvas_view_port.height as f32 / canvas_height as f32;
+
+    [
+        Vertex {
+            position: [-1.0 * a, 1.0 * b],
+            tex_coords: [u, v],
+        },
+        Vertex {
+            position: [-1.0 * a, -1.0 * b],
+            tex_coords: [u, v + vv],
+        },
+        Vertex {
+            position: [1.0 * a, 1.0 * b],
+            tex_coords: [u + uu, v],
+        },
+        Vertex {
+            position: [1.0 * a, -1.0 * b],
+            tex_coords: [u + uu, v + vv],
+        },
+    ]
+}
+
+impl<FB: FrameBuffer + Send + Sync + 'static> eframe::App for EguiView<FB> {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        match self.terminate_rx.try_recv() {
+            Err(broadcast::error::TryRecvError::Empty) => {}
+            _ => {
+                ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                return;
+            }
+        };
+
+        loop {
+            match self.stats_rx.try_recv() {
+                Err(broadcast::error::TryRecvError::Empty) => break,
+                Ok(stats) => {
+                    self.latest_stats = stats;
+                    break;
+                }
+                Err(broadcast::error::TryRecvError::Closed) => {
+                    unreachable!("where stats?");
+                }
+                Err(broadcast::error::TryRecvError::Lagged(_)) => continue,
+            }
+        }
+
+        for (i, vp) in self.viewports.iter().copied().enumerate() {
+            if i == 0 {
+                // first view port on main window
+                self.draw_canvas(ctx, i, vp);
+                self.ui.draw_ui(
+                    i as u32,
+                    ctx,
+                    &self.advertised_endpoints,
+                    self.latest_stats.connections,
+                    self.latest_stats.ips,
+                    self.latest_stats.legacy_ips,
+                    self.latest_stats.bytes_per_s,
+                );
+            } else {
+                let child_requested_close = ctx.show_viewport_immediate(
+                    egui::ViewportId::from_hash_of(format!("viewport-{i}")),
+                    egui::ViewportBuilder::default()
+                        .with_title(format!("Viewport {i} | Breakwater")),
+                    |ctx, class| {
+                        assert!(
+                            class == egui::ViewportClass::Immediate,
+                            "This egui backend doesn't support multiple viewports"
+                        );
+
+                        if ctx.input(|i| i.viewport().close_requested()) {
+                            // should close
+                            return true;
+                        }
+
+                        self.draw_canvas(ctx, i, vp);
+                        self.ui.draw_ui(
+                            i as u32,
+                            ctx,
+                            &self.advertised_endpoints,
+                            self.latest_stats.connections,
+                            self.latest_stats.ips,
+                            self.latest_stats.legacy_ips,
+                            self.latest_stats.bytes_per_s,
+                        );
+
+                        // should close
+                        false
+                    },
+                );
+
+                if child_requested_close {
+                    ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                }
+            }
+        }
+        ctx.request_repaint();
+    }
+}

--- a/breakwater/src/sinks/mod.rs
+++ b/breakwater/src/sinks/mod.rs
@@ -9,6 +9,8 @@ use crate::{
     statistics::{StatisticsEvent, StatisticsInformationEvent},
 };
 
+#[cfg(feature = "egui")]
+pub mod egui;
 pub mod ffmpeg;
 #[cfg(feature = "native-display")]
 pub mod native_display;
@@ -28,6 +30,10 @@ pub enum Error {
 
     #[snafu(display("ffmpeg error"), context(false))]
     FfmpegError { source: ffmpeg::Error },
+
+    #[cfg(feature = "egui")]
+    #[snafu(display("egui error"), context(false))]
+    EguiError { source: egui::Error },
 }
 
 // The stabilization of async functions in traits in Rust 1.75 did not include support for using traits containing async

--- a/docs/custom-overlay.md
+++ b/docs/custom-overlay.md
@@ -1,0 +1,119 @@
+# How to build a custom overlay for breakwater
+
+## Create a new project that compiles to a dynamic library
+
+```bash
+cargo init --lib my-awesome-overlay
+```
+
+`Cargo.toml`
+```toml
+[package]
+name = "my-awesome-overlay"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+breakwater-egui-overlay = { git = "https://github.com/sbernauer/breakwater" }
+
+[lib]
+crate-type = ["dylib"]
+```
+
+## Add Boilerplate
+
+### Export a function that exposes some version information for version checks
+
+```rust
+#[unsafe(no_mangle)]
+pub extern "C" fn versions() -> breakwater_egui_overlay::Versions {
+    breakwater_egui_overlay::VERSIONS
+}
+```
+
+### (Optional) Create function that breakwater will call for setup and teardown
+
+```rust
+static NEW_FN: breakwater_egui_overlay::New = ui_new as _;
+extern "C" fn ui_new(data: *mut std::ffi::c_void) {
+    // data points to custum your data
+
+    println!("Hello breakwater");
+}
+static DROP_FN: breakwater_egui_overlay::Drop = drop as _;
+extern "C" fn drop(data: *mut std::ffi::c_void) {
+    // data points to custum your data
+    
+    println!("Goodbye breakwater");
+}
+```
+
+### Put everything together
+
+```rust
+pub const OVERLAY: DynamicOverlay = DynamicOverlay {
+    // you may use this pointer for custom data.
+    // breakwater will pass this pointer to all calls.
+    data: std::ptr::null_mut(),
+
+    // add your setup function here other wise `std::ptr::null()`
+    new: &raw const NEW_FN,
+
+    // add your draw_ui function here. THIS IS REQUIRED!
+    draw_ui: draw_ui as _,
+    
+    // add your teradown function here other wise `std::ptr::null()`
+    drop: &raw const DROP_FN,
+};
+
+// expose your overlay
+#[unsafe(no_mangle)]
+#[allow(improper_ctypes_definitions)]
+pub extern "C" fn new() -> breakwater_egui_overlay::DynamicOverlay {
+    OVERLAY
+}
+```
+
+## Implement your `draw_ui` function
+
+```rust
+#[allow(improper_ctypes_definitions)]
+extern "C" fn draw_ui(
+    _: *mut std::ffi::c_void,
+    viewport_idx: u32,
+    ctx: &egui::Context,
+    _advertised_endpoints: &[String],
+    connections: u32,
+    ips: u32,
+    legacy_ips: u32,
+    bytes_per_s: u64,
+) { 
+  // your fancy egui widgets go here
+}
+```
+
+## Compile and use
+
+Compile your overlay
+
+```bash
+cargo build
+cargo build --release
+# find your overlay in ./target/{debug,release}/my-awesome-overlay.so
+```
+
+Use it with breakwater
+
+```bash
+breakwater --ui path/to/your/overlay.so
+```
+
+**Note**: It is important that you match the compiler version and configuration between breakwater and your overlay.
+That includes that you only use the `--release` version of breakwater with the `--release` version of your overlay.
+
+## Examples
+
+- [38c3 overlay](https://github.com/bits0rcerer/breakwater-38c3-overlay)
+  - you can use this as a template and customize it to your needs
+
+You can find implementation details [here](../breakwater-egui-overlay/src/lib.rs)


### PR DESCRIPTION
This PR introduces a new type of DisplaySink as an alternative to the current native display.

The new native display:
- can open multiple windows that may show different/overlapping/same parts of the pixelflut canvas
- has predictable names for its windows which helps binding them to outputs in your favorite window manager
- comes with a builtin overlay on the first viewport featuring basic stats, information
- can load custom third-party overlays from dynamic shared libraries. [example](https://github.com/bits0rcerer/breakwater-38c3-overlay)