### PR TITLE
fix: Ensure stat information updates are send periodically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensures statistic information updates are send periodically ([#49])
+
+[#49]: https://github.com/sbernauer/breakwater/pull/49
+
 ## [0.16.3] - 2025-01-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Ensures statistic information updates are send periodically ([#49])
+- Ensure statistic information updates are send periodically ([#49])
 
 [#49]: https://github.com/sbernauer/breakwater/pull/49
 

--- a/breakwater/src/main.rs
+++ b/breakwater/src/main.rs
@@ -127,7 +127,7 @@ async fn main() -> Result<(), Error> {
     .context(StartPrometheusExporterSnafu)?;
 
     let server_listener_thread = tokio::spawn(async move { server.start().await });
-    let statistics_thread = tokio::spawn(async move { statistics.start().await });
+    let statistics_thread = tokio::spawn(async move { statistics.run().await });
     let prometheus_exporter_thread = tokio::spawn(async move { prometheus_exporter.run().await });
 
     let mut display_sinks = Vec::<Box<dyn DisplaySink<SimpleFrameBuffer> + Send>>::new();

--- a/breakwater/src/statistics.rs
+++ b/breakwater/src/statistics.rs
@@ -143,7 +143,7 @@ impl Statistics {
     pub async fn run(&mut self) -> Result<(), Error> {
         let mut statistics_information_event = StatisticsInformationEvent::default();
 
-        let mut stat_report = interval(STATS_REPORT_INTERVAL);
+        let mut stats_report = interval(STATS_REPORT_INTERVAL);
         let (mut stats_save, save_file) = match &self.statistics_save_mode {
             StatisticsSaveMode::Disabled => (interval(Duration::MAX), None),
             StatisticsSaveMode::Enabled {
@@ -167,7 +167,7 @@ impl Statistics {
                 },
                 // Cancellation safety: This method is cancellation safe. If tick is used as the branch in a tokio::select!
                 // and another branch completes first, then no tick has been consumed.
-                _ = stat_report.tick() => {
+                _ = stats_report.tick() => {
                     statistics_information_event = self.calculate_statistics_information_event(
                         &statistics_information_event,
                         STATS_REPORT_INTERVAL,


### PR DESCRIPTION
In https://github.com/sbernauer/breakwater/pull/48 we noticed that we did not send statistic information updates periodically in case no stats are send.

This PR fixes this and ensures statistic information updates are send periodically.