### PR TITLE
chore: Relax shared memory size check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Relax shared memory size check. It now only warns when the shared memory is too big.
+  This e.g. might be the case when pixelflut-v6 crates the shared memory, as it also has statistics bytes after the framebuffer ([#63])
+
+[#63]: https://github.com/sbernauer/breakwater/pull/63
+
 ## [0.18.1] - 2025-05-02
 
 ### Fixed

--- a/breakwater-parser/src/framebuffer/shared_memory.rs
+++ b/breakwater-parser/src/framebuffer/shared_memory.rs
@@ -3,7 +3,7 @@ use std::{cell::UnsafeCell, pin::Pin};
 
 use color_eyre::eyre::{self, Context, bail};
 use shared_memory::{Shmem, ShmemConf, ShmemError};
-use tracing::{debug, info, instrument};
+use tracing::{debug, info, instrument, warn};
 
 use super::FrameBuffer;
 use crate::framebuffer::FB_BYTES_PER_PIXEL;
@@ -112,10 +112,15 @@ impl SharedMemoryFrameBuffer {
         shared_memory.set_owner(false);
 
         let actual_size = shared_memory.len();
-        if actual_size != target_size {
+        if actual_size < target_size {
             bail!(
-                "The shared memory had the wrong size! Expected {target_size} bytes, \
-                        but it has {actual_size} bytes."
+                "The shared memory is too small! Expected at least {target_size} bytes, \
+                        but it has {actual_size} bytes instead."
+            );
+        } else if actual_size > target_size {
+            warn!(
+                "The shared memory is too big! Expected at maximum {target_size} bytes, \
+                        but it has {actual_size} bytes instead."
             );
         }
 


### PR DESCRIPTION
It now only warns when the shared memory is too big.
This e.g. might be the case when pixelflut-v6 crates the shared memory, as it also has statistics bytes after the framebuffer.