### PR TITLE
feat: Add NDI support

### DIFF
--- a/.github/actions/install-ndi/action.yml
+++ b/.github/actions/install-ndi/action.yml
@@ -7,16 +7,18 @@ runs:
       run: |
         set -euo pipefail
 
-        # Keep this URL in sync with default.nix.
-        url="https://downloads.ndi.tv/SDK/NDI_SDK_Linux/Install_NDI_SDK_v6_Linux.tar.gz"
-        curl -fsSL "$url" -o ndi-sdk.tar.gz
+        curl -fsSL "https://downloads.ndi.tv/SDK/NDI_SDK_Linux/Install_NDI_SDK_v6_Linux.tar.gz" -o ndi-sdk.tar.gz
         tar -xf ndi-sdk.tar.gz
 
         # The installer is a self-extracting archive that pages through the EULA
-        # and then prompts to accept it. `yes` accepts it non-interactively.
-        yes | PAGER=cat ./Install_NDI_SDK_v6_Linux.sh >/dev/null
+        # and then prompts to accept it. Feed it `y` to accept non-interactively.
+        # `yes` dies with EPIPE once the installer stops reading stdin, which is
+        # expected, so `|| true` keeps it from tripping pipefail.
+        { yes || true; } | PAGER=cat ./Install_NDI_SDK_v6_Linux.sh >/dev/null
 
         sdk="NDI SDK for Linux"
+        # Fail loudly if the installer did not extract the SDK as expected.
+        test -d "$sdk"
         # ndi-sdk-sys's build.rs looks for the header in /usr/include by default
         # and links `-lndi` without emitting a link-search path, so libndi.so
         # needs to live in a standard library directory.

--- a/.github/actions/install-ndi/action.yml
+++ b/.github/actions/install-ndi/action.yml
@@ -1,0 +1,25 @@
+name: Install NDI SDK on x86_64 Linux
+description: Downloads and installs the NDI SDK so the `ndi` feature can be built.
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+
+        # Keep this URL in sync with default.nix.
+        url="https://downloads.ndi.tv/SDK/NDI_SDK_Linux/Install_NDI_SDK_v6_Linux.tar.gz"
+        curl -fsSL "$url" -o ndi-sdk.tar.gz
+        tar -xf ndi-sdk.tar.gz
+
+        # The installer is a self-extracting archive that pages through the EULA
+        # and then prompts to accept it. `yes` accepts it non-interactively.
+        yes | PAGER=cat ./Install_NDI_SDK_v6_Linux.sh >/dev/null
+
+        sdk="NDI SDK for Linux"
+        # ndi-sdk-sys's build.rs looks for the header in /usr/include by default
+        # and links `-lndi` without emitting a link-search path, so libndi.so
+        # needs to live in a standard library directory.
+        sudo cp "$sdk/include/"*.h /usr/include/
+        sudo cp -P "$sdk/lib/x86_64-linux-gnu/"libndi.so* /usr/lib/x86_64-linux-gnu/
+        sudo ldconfig

--- a/.github/actions/install-ndi/action.yml
+++ b/.github/actions/install-ndi/action.yml
@@ -1,4 +1,4 @@
-name: Install NDI SDK on x86_64 Linux
+name: Install NDI SDK on Linux
 description: Downloads and installs the NDI SDK so the `ndi` feature can be built.
 runs:
   using: composite

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,10 +199,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target=${{ matrix.target }} --no-default-features --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display,vnc
+          args: --target=${{ matrix.target }} --no-default-features --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display
       # I couldn't get pkg-config to work on Windows, so we omit the vnc feature
       - if: runner.os == 'Windows'
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target=${{ matrix.target }} --no-default-features --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display,vnc,ndi
+          args: --target=${{ matrix.target }} --no-default-features --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display,ndi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features --all-targets
+          args: --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display,vnc --all-targets
       - name: Test vnc feature
         uses: actions-rs/cargo@v1
         with:
@@ -184,7 +184,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target=${{ matrix.target }} --all-features
+          args: --target=${{ matrix.target }} --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display,vnc
       # pkg-config on MaxOS and Windows is a pain!
       # As it is only needed for VNC, we disable that feature here
       - if: runner.os == 'macOS' || runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,15 +196,9 @@ jobs:
           # ndi-sdk-sys (behind the ndi features) only supports Linux x86 (no aarch64) so far.
           # We already run the tests on x86 Linux with all features above.
           args: --target=${{ matrix.target }} --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display,vnc
-      # I couldn't get pkg-config to work on macOS, so we omit the vnc feature
-      - if: runner.os == 'macOS'
+      # I couldn't get pkg-config to work on macOS and Windows, so we omit the vnc and ndi feature
+      - if: runner.os == 'macOS' || runner.os == 'Windows'
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --target=${{ matrix.target }} --no-default-features --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display
-      # I couldn't get pkg-config to work on Windows, so we omit the vnc feature
-      - if: runner.os == 'Windows'
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=${{ matrix.target }} --no-default-features --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display,ndi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display,vnc --all-targets
+          args: --all-features --all-targets
       - name: Test vnc feature
         uses: actions-rs/cargo@v1
         with:
@@ -184,7 +184,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target=${{ matrix.target }} --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display,vnc
+          args: --target=${{ matrix.target }} --all-features
       # pkg-config on MaxOS and Windows is a pain!
       # As it is only needed for VNC, we disable that feature here
       - if: runner.os == 'macOS' || runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,8 @@ jobs:
           override: true
       - name: Install libvncserver-dev
         run: sudo apt update && sudo apt install -y libvncserver-dev
+      - name: Install NDI SDK
+        uses: ./.github/actions/install-ndi
       - name: Run clippy action to produce annotations (all features)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,19 +75,24 @@ jobs:
           override: true
       - name: Install libvncserver-dev
         run: sudo apt update && sudo apt install -y libvncserver-dev
-      - name: Run clippy action to produce annotations
+      - name: Run clippy action to produce annotations (all features)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: actions-rs/clippy-check@v1
         if: env.GITHUB_TOKEN != null
         with:
-          args: --all-targets -- -D warnings
+          args: --all-targets --all-features -- -D warnings
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run clippy manually without annotations
+      - name: Run clippy manually without annotations (no default features)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: env.GITHUB_TOKEN == null
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets --no-default-features -- -D warnings
+      - name: Run clippy manually without annotations (all features)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: env.GITHUB_TOKEN == null
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   run_rustdoc:
     name: Run RustDoc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,11 +191,18 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target=${{ matrix.target }} --all-features
-      # pkg-config on MaxOS and Windows is a pain!
-      # As it is only needed for VNC, we disable that feature here
-      - if: runner.os == 'macOS' || runner.os == 'Windows'
+          # ndi-sdk-sys (behind the ndi features) only supports Linux x86 (no aarch64) so far.
+          # We already run the tests on x86 Linux with all features above.
+          args: --target=${{ matrix.target }} --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display,vnc
+      # I couldn't get pkg-config to work on macOS, so we omit the vnc feature
+      - if: runner.os == 'macOS'
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target=${{ matrix.target }} --no-default-features --features egui
+          args: --target=${{ matrix.target }} --no-default-features --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display,vnc
+      # I couldn't get pkg-config to work on Windows, so we omit the vnc feature
+      - if: runner.os == 'Windows'
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target=${{ matrix.target }} --no-default-features --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display,vnc,ndi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,8 @@ jobs:
           override: true
       - name: Install libvncserver-dev
         run: sudo apt update && sudo apt install -y libvncserver-dev
+      - name: Install NDI SDK
+        uses: ./.github/actions/install-ndi
       - name: Test with all features turned off
         uses: actions-rs/cargo@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add an [NDI](https://ndi.video/) sink.
+  It's a high-quality low-latency network video streaming protocol, i.e. ideal for Pixelflut ([#79]).
+
 ### Fixed
 
 - Raise an error in case the `statistics.json` is written by an older version and can not be deserialized any more.
   Previously, we would ignore such an error, which results in all statistics being lost ([#77]).
 
 [#77]: https://github.com/sbernauer/breakwater/pull/77
+[#79]: https://github.com/sbernauer/breakwater/pull/79
 
 ## [0.20.0] - 2026-01-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex 1.3.0",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +485,7 @@ dependencies = [
  "libloading 0.9.0",
  "local-ip-address",
  "memadvise",
+ "ndi-sdk-sys",
  "number_prefix",
  "page_size 0.6.0",
  "prometheus_exporter",
@@ -2599,6 +2620,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndi-sdk-sys"
+version = "0.1.0"
+source = "git+https://github.com/kleinesfilmroellchen/rust-ndi-sdk.git?branch=main#c1f8085e2698e9871f2a7e96c17014fe300e7908"
+dependencies = [
+ "bindgen 0.71.1",
+ "num",
+ "num_enum",
+ "regex",
+ "static_assertions",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,12 +2781,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -2780,6 +2836,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -4846,7 +4913,7 @@ name = "vncserver"
 version = "0.2.2"
 source = "git+https://github.com/sbernauer/libvnc-rs.git#2b3418a1f2aa163ec968c0b66b1b025506c3e00e"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "cc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ local-ip-address = "0.6.3"
 memadvise = "0.1"
 memchr = "2.7"
 number_prefix = "0.4"
+ndi-sdk-sys = { git = "https://github.com/kleinesfilmroellchen/rust-ndi-sdk.git", branch = "main" }
 page_size = "0.6"
 pixelbomber = "1.1"
 prometheus_exporter = "0.8"

--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ It claims to be the fastest Pixelflut server in existence - at least at the time
 
 # Features
 1. Accepts Pixelflut commands
-2. It can start a native display window in your graphical environment
-3. Simultaneously it can provide a VNC server so that everybody can watch
-4. As an alternative it can stream to a RTMP sink, so that you can e.g. directly live-stream into Twitch or YouTube
+2. Many possible outputs:
+  - Start a native display window in your graphical environment
+  - Start a VNC server so that everybody can watch
+  - Stream to an RTMP sink, so that you can e.g. directly live-stream into Twitch or YouTube
+  - Provide an [NDI](https://ndi.video) source
+  - … all of these can be used at the same time
 5. Exposes Prometheus metrics
 6. IPv6 and legacy IP support
 
@@ -93,6 +96,10 @@ Options:
           VNC server listen address to bind to (multiple can be specified). Only one address of each IP version can be specified
       --native-display
           Enable native display output. This requires some form of graphical system (so will probably not work on your server)
+      --ndi
+          Enable the NDI source. Set the source name with --ndi-source-name
+      --ndi-source-name <NDI_SOURCE_NAME>
+          Set the readable NDI source name. NDI output is not enabled unless you specify --ndi [default: "breakwater canvas"]
       --viewport <VIEWPORT>
           Specify a view port to display the canvas or a certain part of it. Format: `<offset_x>x<offset_y>,<width>x<height>`. Might be specified multiple times for more than one viewport. Useful for multi-projector setups. Defaults to display the entire canvas. Implies --native-display
       --advertised-endpoints <ADVERTISED_ENDPOINTS>
@@ -118,6 +125,7 @@ As of writing the following features are supported:
 
 * `egui` (enabled by default): Enables an advanced customizable graphical frontend on your local system. Please note that this requires a graphical environment.
 * `native-display` (disabled by default): Enables a minimalist graphical window on your local system. Please note that this requires a graphical environment.
+* `ndi` (disabled by default): Enables NDI video streaming. This requires the proprietary NDI SDK to be installed, see below.
 * `vnc` (enabled by default): Starts a VNC server, where users can connect to. Needs `libvncserver-dev` to be installed. Please note that the VNC server offers basically no latency, but consumes quite some CPU.
 * `alpha` (disabled by default): Respect alpha values during `PX` commands. Disabled by default as this can cause performance degradation.
 * `binary-set-pixel` (disabled by default): Allows use of the `PB` command.
@@ -126,8 +134,26 @@ As of writing the following features are supported:
 To e.g. turn the VNC server off, build with
 
 ```bash
-cargo run --release --no-default-features # --features alpha,vnc to explicitly enable
+cargo run --release --no-default-features
 ```
+
+Enable (any number of) desired features with
+
+```bash
+cargo run --release --features vnc,native-display,alpha
+```
+
+## NDI
+
+[NDI](https://ndi.video) is a network video streaming protocol. Its major advantages for Pixelflut are the low latency, efficiency, high quality (almost lossless), automatic discovery via mDNS, and support in lots of software (e.g. OBS and GStreamer) and professional hardware. You should be familiar with the architecture and operating principle of NDI if you want to use it.
+
+In order to use NDI, you need to install the *proprietary* NDI SDK from Vizrt/NewTek, which works on x86_64 only and requires SSE4.2. DistroAV, the OBS plugin for NDI support, has [excellent installation documentation](https://github.com/DistroAV/DistroAV/wiki/1.-Installation#required-components---ndi-runtime). If your Linux distribution offers a package (e.g. nonfree Fedora, Arch User Repository), use that instead. If you are still running into issues, your install location is probably unusual and/or you are missing Clang/LLVM. Refer to the [rust-ndi-sdk](https://github.com/kleinesfilmroellchen/rust-ndi-sdk) usage instructions in this case. NDI is untested on Windows, but should work as long as you install the Windows SDK and follow rust-ndi-sdk’s instructions. As of writing (2026-06), rust-ndi-sdk does not support macOS.
+
+Tested versions of the NDI SDK include version 6.3.2.0; any NDI 6 release should work.
+
+Breakwater’s use of NDI is conventional. The framerate and resolution of the NDI stream are set according to the command-line parameters (`--width`, `--height`, and `--fps`). Pixel format is `RGBX` (aka. 32-bit aligned RGB without alpha). No audio stream is added. The source is advertised via mDNS and does not use any custom groups.
+
+Disclaimer: This project is not in any way affiliated with NDI® or NewTek/Vizrt. NDI is a registered trademark of NDI Vizrt AB.
 
 ## Custom overlay for the egui native display
 

--- a/breakwater-parser/src/original.rs
+++ b/breakwater-parser/src/original.rs
@@ -148,15 +148,18 @@ impl<FB: FrameBuffer> Parser for OriginalParser<FB> {
 
                             let alpha_comp = 0xff - alpha;
                             let current = unsafe { self.fb.get_unchecked(x, y) };
-                            let r = (rgba >> 16) & 0xff;
-                            let g = (rgba >> 8) & 0xff;
-                            let b = rgba & 0xff;
+                            let red = (rgba >> 16) & 0xff;
+                            let green = (rgba >> 8) & 0xff;
+                            let blue = rgba & 0xff;
 
-                            let r: u32 = (((current >> 24) & 0xff) * alpha_comp + r * alpha) / 0xff;
-                            let g: u32 = (((current >> 16) & 0xff) * alpha_comp + g * alpha) / 0xff;
-                            let b: u32 = (((current >> 8) & 0xff) * alpha_comp + b * alpha) / 0xff;
+                            let red: u32 =
+                                (((current >> 24) & 0xff) * alpha_comp + red * alpha) / 0xff;
+                            let green: u32 =
+                                (((current >> 16) & 0xff) * alpha_comp + green * alpha) / 0xff;
+                            let blue: u32 =
+                                (((current >> 8) & 0xff) * alpha_comp + blue * alpha) / 0xff;
 
-                            self.fb.set(x, y, (r << 16) | (g << 8) | b);
+                            self.fb.set(x, y, (red << 16) | (green << 8) | blue);
                             continue;
                         }
 

--- a/breakwater-parser/src/original.rs
+++ b/breakwater-parser/src/original.rs
@@ -236,28 +236,27 @@ impl<FB: FrameBuffer> Parser for OriginalParser<FB> {
                     i += len_in_bytes;
                     last_byte_parsed = i;
                     continue;
-                } else {
-                    // We need to round down to the 4 bytes of a pixel alignment
-                    let pixel_bytes: usize = bytes_left_in_buffer / 4 * 4;
-
-                    // The client requested to write more bytes that are currently in the buffer, we need to remember
-                    // what the client is doing.
-                    let mut current_index =
-                        start_x as usize + start_y as usize * self.fb.get_width();
-                    current_index += self.fb.set_multi_from_start_index(current_index, unsafe {
-                        slice::from_raw_parts(buffer.as_ptr().add(i), pixel_bytes)
-                    });
-
-                    self.remaining_pixel_sync = Some(RemainingPixelSync {
-                        current_index,
-                        bytes_remaining: len_in_bytes - pixel_bytes,
-                    });
-
-                    // Nothing to do left, we can early return
-                    // I have absolutely no idea why we need to subtract 1 here, but it is what it is. At least we have
-                    // tests for this madness :)
-                    return i + pixel_bytes.saturating_sub(1);
                 }
+
+                // We need to round down to the 4 bytes of a pixel alignment
+                let pixel_bytes: usize = bytes_left_in_buffer / 4 * 4;
+
+                // The client requested to write more bytes that are currently in the buffer, we need to remember
+                // what the client is doing.
+                let mut current_index = start_x as usize + start_y as usize * self.fb.get_width();
+                current_index += self.fb.set_multi_from_start_index(current_index, unsafe {
+                    slice::from_raw_parts(buffer.as_ptr().add(i), pixel_bytes)
+                });
+
+                self.remaining_pixel_sync = Some(RemainingPixelSync {
+                    current_index,
+                    bytes_remaining: len_in_bytes - pixel_bytes,
+                });
+
+                // Nothing to do left, we can early return
+                // I have absolutely no idea why we need to subtract 1 here, but it is what it is. At least we have
+                // tests for this madness :)
+                return i + pixel_bytes.saturating_sub(1);
             }
             if current_command & 0x00ff_ffff_ffff_ffff == OFFSET_PATTERN {
                 i += 7;

--- a/breakwater-parser/src/refactored.rs
+++ b/breakwater-parser/src/refactored.rs
@@ -151,15 +151,15 @@ impl<FB: FrameBuffer> RefactoredParser<FB> {
 
         let alpha_comp = 0xff - alpha;
         let current = unsafe { self.fb.get_unchecked(x, y) };
-        let r = (rgba >> 16) & 0xff;
-        let g = (rgba >> 8) & 0xff;
-        let b = rgba & 0xff;
+        let red = (rgba >> 16) & 0xff;
+        let green = (rgba >> 8) & 0xff;
+        let blue = rgba & 0xff;
 
-        let r: u32 = (((current >> 24) & 0xff) * alpha_comp + r * alpha) / 0xff;
-        let g: u32 = (((current >> 16) & 0xff) * alpha_comp + g * alpha) / 0xff;
-        let b: u32 = (((current >> 8) & 0xff) * alpha_comp + b * alpha) / 0xff;
+        let red: u32 = (((current >> 24) & 0xff) * alpha_comp + red * alpha) / 0xff;
+        let green: u32 = (((current >> 16) & 0xff) * alpha_comp + green * alpha) / 0xff;
+        let blue: u32 = (((current >> 8) & 0xff) * alpha_comp + blue * alpha) / 0xff;
 
-        self.fb.set(x, y, (r << 16) | (g << 8) | b);
+        self.fb.set(x, y, (red << 16) | (green << 8) | blue);
     }
 
     #[inline(always)]

--- a/breakwater/Cargo.toml
+++ b/breakwater/Cargo.toml
@@ -26,6 +26,7 @@ egui = { workspace = true, optional = true }
 libloading = { workspace = true, optional = true }
 local-ip-address.workspace = true
 memadvise.workspace = true
+ndi-sdk-sys = { workspace = true, optional = true }
 number_prefix.workspace = true
 page_size.workspace = true
 prometheus_exporter.workspace = true
@@ -56,6 +57,7 @@ binary-sync-pixels = ["breakwater-parser/binary-sync-pixels"]
 egui = ["dep:breakwater-egui-overlay", "dep:bytemuck", "dep:eframe", "dep:egui", "dep:libloading"]
 native-display = ["dep:softbuffer", "dep:winit"]
 vnc = ["dep:vncserver"]
+ndi = ["dep:ndi-sdk-sys"]
 
 [lints]
 workspace = true

--- a/breakwater/src/cli_args.rs
+++ b/breakwater/src/cli_args.rs
@@ -91,6 +91,15 @@ pub struct CliArgs {
     #[clap(long)]
     pub native_display: bool,
 
+    /// Enable the NDI source. Set the source name with --ndi-source-name.
+    #[cfg(feature = "ndi")]
+    #[clap(long)]
+    pub ndi: bool,
+    /// Set the readable NDI source name. NDI output is not enabled unless you specify --ndi.
+    #[cfg(feature = "ndi")]
+    #[clap(long, default_value = "breakwater canvas")]
+    pub ndi_source_name: String,
+
     /// Specify a view port to display the canvas or a certain part of it. Format: `<offset_x>x<offset_y>,<width>x<height>`.
     /// Might be specified multiple times for more than one viewport. Useful for multi-projector setups.
     /// Defaults to display the entire canvas.

--- a/breakwater/src/main.rs
+++ b/breakwater/src/main.rs
@@ -140,6 +140,24 @@ async fn main() -> eyre::Result<()> {
         }
     }
 
+    #[cfg(feature = "ndi")]
+    {
+        use crate::sinks::ndi::NdiSink;
+
+        if let Some(ndi_sink) = NdiSink::new(
+            fb.clone(),
+            &args,
+            statistics_tx.clone(),
+            statistics_information_rx.resubscribe(),
+            terminate_signal_rx.resubscribe(),
+        )
+        .await
+        .context("failed to create ndi sink")?
+        {
+            display_sinks.push(Box::new(ndi_sink));
+        }
+    }
+
     let mut ffmpeg_thread_present = false;
     if let Some(ffmpeg_sink) = FfmpegSink::new(
         fb.clone(),

--- a/breakwater/src/sinks/mod.rs
+++ b/breakwater/src/sinks/mod.rs
@@ -14,6 +14,8 @@ pub mod egui;
 pub mod ffmpeg;
 #[cfg(all(feature = "native-display", not(feature = "egui")))]
 pub mod native_display;
+#[cfg(feature = "ndi")]
+pub mod ndi;
 #[cfg(feature = "vnc")]
 pub mod vnc;
 

--- a/breakwater/src/sinks/ndi.rs
+++ b/breakwater/src/sinks/ndi.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use breakwater_parser::FrameBuffer;
-use color_eyre::eyre::{self, Context, eyre};
+use color_eyre::eyre::{self, Context, ContextCompat};
 use ndi_sdk_sys::{
     four_cc::FourCCVideo,
     frame::video::VideoFrame,
@@ -13,7 +13,7 @@ use ndi_sdk_sys::{
     sender::{NDISender, NDISenderBuilder},
 };
 use tokio::sync::{broadcast, mpsc};
-use tracing::{debug, error, info, instrument};
+use tracing::{error, info, instrument, trace};
 
 use crate::{
     cli_args::CliArgs,
@@ -43,9 +43,8 @@ impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NdiSink<FB> {
             return Ok(None);
         }
 
-        let v = sdk::version();
         info!(
-            version = v.unwrap_or("NDI SDK version unavailable"),
+            version = sdk::version().unwrap_or("NDI SDK version unavailable"),
             "NDI SDK version",
         );
         sdk::initialize().context("failed to initialize NDI SDK")?;
@@ -54,10 +53,14 @@ impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NdiSink<FB> {
             .name(&cli_args.ndi_source_name)?
             .clock_video(true)
             .build()
-            .unwrap();
+            .context("failed to build NDI sender")?;
 
         info!(
-            name = source.get_source().name().to_str().unwrap(),
+            name = source
+                .get_source()
+                .name()
+                .to_str()
+                .context("NDI source name is not a valid utf-8 string")?,
             "Started NDI source",
         );
 
@@ -71,7 +74,7 @@ impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NdiSink<FB> {
 
     #[instrument(skip(self), err)]
     async fn run(&mut self) -> eyre::Result<()> {
-        let fb_clone = self.fb.clone();
+        let fb = self.fb.clone();
         let mut terminate_signal_rx = self.terminate_signal_rx.resubscribe();
         let source = self.source.clone();
         let target_fps = self.target_fps;
@@ -79,22 +82,26 @@ impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NdiSink<FB> {
         tokio::task::spawn_blocking(move || {
             let mut frame = VideoFrame::new();
             frame.set_resolution(
-                Resolution::try_new(fb_clone.get_width(), fb_clone.get_height())
-                    .ok_or(eyre!("Resolution is not safe for NDI"))?,
+                Resolution::try_new(fb.get_width(), fb.get_height())
+                    .context("Resolution is not safe for NDI")?,
             )?;
             // The framebuffer is "technically" RGBA, but the alpha values are always zero.
             // If we were to set RGBA here, the image would be entirely black :)
             frame.set_four_cc(FourCCVideo::RGBX)?;
             frame.set_frame_rate((target_fps as i32).into());
-            frame.try_alloc()?;
+            frame
+                .try_alloc()
+                .context("failed to allocate NDI framebuffer")?;
 
             loop {
                 if terminate_signal_rx.try_recv().is_ok() {
-                    return eyre::Result::<()>::Ok(());
+                    return eyre::Ok(());
                 }
 
-                let source_frame_data = fb_clone.as_bytes();
-                let (target_data, info) = frame.video_data_mut()?;
+                let source_frame_data = fb.as_bytes();
+                let (target_data, info) = frame
+                    .video_data_mut()
+                    .context("failed to get mutable access to the NDI frame")?;
                 if info.size != source_frame_data.len() {
                     error!(
                         framebuffer_size = source_frame_data.len(),
@@ -107,8 +114,10 @@ impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NdiSink<FB> {
 
                 // Using async sending would not improve anything, since we run clocked video anyways, in which case async also always blocks.
                 // Doing this instead allows us to more easily reuse the frame allocation.
-                source.send_video_sync(&frame)?;
-                debug!(frame = ?frame, "Sent NDI video frame");
+                source
+                    .send_video_sync(&frame)
+                    .context("failed to send NDI video frame")?;
+                trace!(frame = ?frame, "Sent NDI video frame");
             }
         })
         .await

--- a/breakwater/src/sinks/ndi.rs
+++ b/breakwater/src/sinks/ndi.rs
@@ -1,0 +1,119 @@
+//! NDI output support.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use breakwater_parser::FrameBuffer;
+use color_eyre::eyre::{self, Context, eyre};
+use ndi_sdk_sys::{
+    four_cc::FourCCVideo,
+    frame::video::VideoFrame,
+    resolution::Resolution,
+    sdk,
+    sender::{NDISender, NDISenderBuilder},
+};
+use tokio::sync::{broadcast, mpsc};
+use tracing::{debug, error, info, instrument};
+
+use crate::{
+    cli_args::CliArgs,
+    sinks::DisplaySink,
+    statistics::{StatisticsEvent, StatisticsInformationEvent},
+};
+
+pub struct NdiSink<FB: FrameBuffer> {
+    fb: Arc<FB>,
+    terminate_signal_rx: broadcast::Receiver<()>,
+    target_fps: u32,
+
+    source: Arc<NDISender>,
+}
+
+#[async_trait]
+impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NdiSink<FB> {
+    #[instrument(skip_all, err)]
+    async fn new(
+        fb: Arc<FB>,
+        cli_args: &CliArgs,
+        _statistics_tx: mpsc::Sender<StatisticsEvent>,
+        _statistics_information_rx: broadcast::Receiver<StatisticsInformationEvent>,
+        terminate_signal_rx: broadcast::Receiver<()>,
+    ) -> eyre::Result<Option<Self>> {
+        if !cli_args.ndi {
+            return Ok(None);
+        }
+
+        let v = sdk::version();
+        info!(
+            version = v.unwrap_or("NDI SDK version unavailable"),
+            "NDI SDK version",
+        );
+        sdk::initialize().context("failed to initialize NDI SDK")?;
+
+        let source = NDISenderBuilder::new()
+            .name(&cli_args.ndi_source_name)?
+            .clock_video(true)
+            .build()
+            .unwrap();
+
+        info!(
+            name = source.get_source().name().to_str().unwrap(),
+            "Started NDI source",
+        );
+
+        Ok(Some(Self {
+            fb,
+            terminate_signal_rx,
+            source: Arc::new(source),
+            target_fps: cli_args.fps,
+        }))
+    }
+
+    #[instrument(skip(self), err)]
+    async fn run(&mut self) -> eyre::Result<()> {
+        let fb_clone = self.fb.clone();
+        let mut terminate_signal_rx = self.terminate_signal_rx.resubscribe();
+        let source = self.source.clone();
+        let target_fps = self.target_fps;
+
+        tokio::task::spawn_blocking(move || {
+            let mut frame = VideoFrame::new();
+            frame.set_resolution(
+                Resolution::try_new(fb_clone.get_width(), fb_clone.get_height())
+                    .ok_or(eyre!("Resolution is not safe for NDI"))?,
+            )?;
+            // The framebuffer is "technically" RGBA, but the alpha values are always zero.
+            // If we were to set RGBA here, the image would be entirely black :)
+            frame.set_four_cc(FourCCVideo::RGBX)?;
+            frame.set_frame_rate((target_fps as i32).into());
+            frame.try_alloc()?;
+
+            loop {
+                if terminate_signal_rx.try_recv().is_ok() {
+                    return eyre::Result::<()>::Ok(());
+                }
+
+                let source_frame_data = fb_clone.as_bytes();
+                let (target_data, info) = frame.video_data_mut()?;
+                if info.size != source_frame_data.len() {
+                    error!(
+                        framebuffer_size = source_frame_data.len(),
+                        ndi_size = info.size,
+                        "Framebuffer size mismatch"
+                    );
+                    continue;
+                }
+                target_data.copy_from_slice(source_frame_data);
+
+                // Using async sending would not improve anything, since we run clocked video anyways, in which case async also always blocks.
+                // Doing this instead allows us to more easily reuse the frame allocation.
+                source.send_video_sync(&frame)?;
+                debug!(frame = ?frame, "Sent NDI video frame");
+            }
+        })
+        .await
+        .context("failed to join NDI sender thread")??;
+
+        Ok(())
+    }
+}

--- a/breakwater/src/tests.rs
+++ b/breakwater/src/tests.rs
@@ -331,7 +331,7 @@ async fn test_binary_sync_pixels_last_pixel<FB: FrameBuffer>(fb: Arc<FB>) {
     input.extend(x.to_le_bytes()); // x
     input.extend(y.to_le_bytes()); // y
     input.extend(1_u32.to_le_bytes()); // length
-    input.extend(0x12345678_u32.to_be_bytes());
+    input.extend(0x1234_5678_u32.to_be_bytes());
 
     input.extend(format!("PX 0 0\nPX {} {y}\nPX {x} {y}\n", x - 1).as_bytes());
     assert_returns(
@@ -367,13 +367,13 @@ async fn test_binary_sync_pixels_in_the_middle<FB: FrameBuffer>(fb: Arc<FB>) {
     let mut rgba = 0_u32;
     for x in 42..fb.get_width() {
         input.extend(format!("PX {x} 13\n").as_bytes());
-        expected += &format!("PX {x} 13 {rgba:06x}\n");
+        let _ = writeln!(expected, "PX {x} 13 {rgba:06x}");
         rgba += 1;
     }
 
     for x in 0..52 {
         input.extend(format!("PX {x} 14\n").as_bytes());
-        expected += &format!("PX {x} 14 {rgba:06x}\n");
+        let _ = writeln!(expected, "PX {x} 14 {rgba:06x}");
         rgba += 1;
     }
 
@@ -395,8 +395,8 @@ async fn test_binary_sync_pixels_exceeding_screen<FB: FrameBuffer>(fb: Arc<FB>) 
     input.extend(x.to_le_bytes()); // x
     input.extend(y.to_le_bytes()); // y
     input.extend(2_u32.to_le_bytes()); // length
-    input.extend(0x12345678_u32.to_be_bytes());
-    input.extend(0x87654321_u32.to_be_bytes());
+    input.extend(0x1234_5678_u32.to_be_bytes());
+    input.extend(0x8765_4321_u32.to_be_bytes());
 
     input.extend(format!("PX {x} {y}\n").as_bytes());
     // As we exceeded the screen nothing should have been set
@@ -438,12 +438,12 @@ async fn test_binary_sync_pixels_larger_than_buffer<FB: FrameBuffer>(fb: Arc<FB>
         for x in 0..fb.get_width() {
             // rgba = 0xdeadbe_u32; // For testing
             input.extend(format!("PX {x} {y}\n").as_bytes());
-            expected += &format!("PX {x} {y} {rgba:06x}\n");
+            let _ = writeln!(expected, "PX {x} {y} {rgba:06x}");
             rgba += 1;
         }
     }
 
-    let mut stream = MockTcpStream::from_bytes(input.to_owned());
+    let mut stream = MockTcpStream::from_bytes(input);
     handle_connection(
         &mut stream,
         ip(),

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,18 @@
-{ pkgs ? import <nixpkgs> {} }:
+# NDI is unfree, so we need to allow unfree packages for the `ndi` feature.
+{ pkgs ? import <nixpkgs> { config.allowUnfree = true; } }:
 
+let
+  # The ndi-sdk-sys crate needs NDI 6 (it references NDIlib_frame_type_source_change,
+  # which only exists from v6 onwards; v5 only has status_change).
+  # Upstream re-published the tarball, so the hash pinned in nixpkgs is stale and we
+  # override it here.
+  ndi = pkgs.ndi-6.overrideAttrs (old: {
+    src = pkgs.fetchurl {
+      url = "https://downloads.ndi.tv/SDK/NDI_SDK_Linux/Install_NDI_SDK_v6_Linux.tar.gz";
+      hash = "sha256-8DFPJFRG3vxIi2POtGiazxqWWu79ray3BXG7IWqMwYM=";
+    };
+  });
+in
 pkgs.stdenv.mkDerivation rec {
   name = "dev-shell";
 
@@ -14,10 +27,16 @@ pkgs.stdenv.mkDerivation rec {
     wayland
     libGL
     libxkbcommon
+
+    # Needed for ndi feature
+    ndi
   ];
 
   LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
   LIBVNCSERVER_HEADER_FILE = "${pkgs.libvncserver.dev}/include/rfb/rfb.h";
+
+  # ndi-sdk-sys's build.rs looks for Processing.NDI.Lib.h here
+  NDI_HEADER_DIR = "${ndi}/include";
 
   # Needed for native-display feature
   WINIT_UNIX_BACKEND = "wayland";


### PR DESCRIPTION
NDI is a high-quality low-latency network video streaming protocol, i.e. ideal for Pixelflut :)

Add command line options to control NDI behavior:
* --ndi enables the NDI output
* --ndi-source-name sets the NDI source name

NDI support is gated behind the `ndi` feature, as (like vnc and others) it requires native dependencies. In this case in particular, you need to install a proprietary library.

For now the implementation depends on my rust-ndi-sdk fork while upstream hasn’t responded yet.

Tested several framerates and resolutions, everything works well.