### PR TITLE
refactor: Don't force sink creation through trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,16 @@ The default settings should provide you with a ready-to-use server.
 | 9100 | Prometheus metrics exporter |
 
 The get a list of options try
+
 ```bash
 cargo run --release -- --help
 ```
+
 <details>
   <summary>Output</summary>
 
 ```bash
-cargo run --release -- --help
+cargo run --release --all-features -- --help
     Finished release [optimized] target(s) in 0.04s
      Running `target/release/breakwater --help`
 Pixelflut server
@@ -76,8 +78,6 @@ Options:
           The size in bytes of the network buffer used for each open TCP connection. Please use at least 64 KB (64_000 bytes) [default: 262144]
   -t, --text <TEXT>
           Text to display on the screen [default: "Pixelflut server (breakwater)"]
-      --font <FONT>
-          The font used to render the text on the screen. Should be a ttf file. If you use the default value a copy that ships with breakwater will be used - no need to download and provide the font [default: Arial.ttf]
   -p, --prometheus-listen-address <PROMETHEUS_LISTEN_ADDRESS>
           Listen address the prometheus exporter should listen on [default: [::]:9100]
       --statistics-save-file <STATISTICS_SAVE_FILE>
@@ -86,32 +86,42 @@ Options:
           Interval (in seconds) in which the statistics save file should be updated [default: 10]
       --disable-statistics-save-file
           Disable periodical saving of statistics into save file
-      --rtmp-address <RTMP_ADDRESS>
-          Enable rtmp streaming to configured address, e.g. `rtmp://127.0.0.1:1935/live/test`
-      --video-save-folder <VIDEO_SAVE_FOLDER>
-          Enable dump of video stream into file. File location will be `<VIDEO_SAVE_FOLDER>/pixelflut_dump_{timestamp}.mp4`
   -c, --connections-per-ip <CONNECTIONS_PER_IP>
           Allow only a certain number of connections per ip address
-      --vnc-listen-address <VNC_LISTEN_ADDRESSES>
-          VNC server listen address to bind to (multiple can be specified). Only one address of each IP version can be specified
       --native-display
           Enable native display output. This requires some form of graphical system (so will probably not work on your server)
-      --ndi
-          Enable the NDI source. Set the source name with --ndi-source-name
-      --ndi-source-name <NDI_SOURCE_NAME>
-          Set the readable NDI source name. NDI output is not enabled unless you specify --ndi [default: "breakwater canvas"]
-      --viewport <VIEWPORT>
-          Specify a view port to display the canvas or a certain part of it. Format: `<offset_x>x<offset_y>,<width>x<height>`. Might be specified multiple times for more than one viewport. Useful for multi-projector setups. Defaults to display the entire canvas. Implies --native-display
-      --advertised-endpoints <ADVERTISED_ENDPOINTS>
-          Specify one or more pixelflut endpoints to display
-      --ui <UI>
-          Provide a path to a dylib containing a custom egui overlay. Implies --native-display
       --shared-memory-name <SHARED_MEMORY_NAME>
           Create (or use an existing) shared memory region for the framebuffer. This enables other applications to read and write Pixel values to the framebuffer or can be used to persist the canvas across restarts
   -h, --help
           Print help
   -V, --version
           Print version
+
+ffmpeg options:
+      --rtmp-address <RTMP_ADDRESS>
+          Enable rtmp streaming to configured address, e.g. `rtmp://127.0.0.1:1935/live/test`
+      --video-save-folder <VIDEO_SAVE_FOLDER>
+          Enable dump of video stream into file. File location will be `<VIDEO_SAVE_FOLDER>/pixelflut_dump_{timestamp}.mp4`
+
+egui options:
+      --viewport <VIEWPORT>
+          Specify a view port to display the canvas or a certain part of it. Format: `<offset_x>x<offset_y>,<width>x<height>`. Might be specified multiple times for more than one viewport. Useful for multi-projector setups. Defaults to display the entire canvas. Implies --native-display
+      --advertised-endpoints <ADVERTISED_ENDPOINTS>
+          Specify one or more pixelflut endpoints to display
+      --ui <UI>
+          Provide a path to a dylib containing a custom egui overlay. Implies --native-display
+
+NDI options:
+      --ndi
+          Enable the NDI source. Set the source name with --ndi-source-name
+      --ndi-source-name <NDI_SOURCE_NAME>
+          Set the readable NDI source name. NDI output is not enabled unless you specify --ndi [default: "breakwater canvas"]
+
+VNC options:
+      --vnc-listen-address <VNC_LISTEN_ADDRESSES>
+          VNC server listen address to bind to (multiple can be specified). Only one address of each IP version can be specified
+      --font <FONT>
+          The font used to render the text on the screen. Should be a ttf file. If you use the default value a copy that ships with breakwater will be used - no need to download and provide the font [default: Arial.ttf]
 ```
 </details>
 

--- a/breakwater/src/cli_args.rs
+++ b/breakwater/src/cli_args.rs
@@ -1,10 +1,6 @@
 use std::net::SocketAddr;
-#[cfg(feature = "vnc")]
-use std::net::{SocketAddrV4, SocketAddrV6};
 
 use clap::Parser;
-#[cfg(feature = "vnc")]
-use color_eyre::eyre::{self, ensure};
 use const_format::formatcp;
 
 pub const DEFAULT_NETWORK_BUFFER_SIZE: usize = 256 * 1024;
@@ -43,12 +39,6 @@ pub struct CliArgs {
     #[clap(short, long, default_value = "Pixelflut server (breakwater)")]
     pub text: String,
 
-    /// The font used to render the text on the screen.
-    /// Should be a ttf file.
-    /// If you use the default value a copy that ships with breakwater will be used - no need to download and provide the font.
-    #[clap(long, default_value = "Arial.ttf")]
-    pub font: String,
-
     /// Listen address the prometheus exporter should listen on.
     #[clap(short, long, default_value = "[::]:9100")]
     pub prometheus_listen_address: String,
@@ -67,23 +57,9 @@ pub struct CliArgs {
     #[clap(long)]
     pub disable_statistics_save_file: bool,
 
-    /// Enable rtmp streaming to configured address, e.g. `rtmp://127.0.0.1:1935/live/test`
-    #[clap(long)]
-    pub rtmp_address: Option<String>,
-
-    /// Enable dump of video stream into file. File location will be `<VIDEO_SAVE_FOLDER>/pixelflut_dump_{timestamp}.mp4`
-    #[clap(long)]
-    pub video_save_folder: Option<String>,
-
     /// Allow only a certain number of connections per ip address
     #[clap(short, long)]
     pub connections_per_ip: Option<u64>,
-
-    /// VNC server listen address to bind to (multiple can be specified).
-    /// Only one address of each IP version can be specified
-    #[cfg(feature = "vnc")]
-    #[clap(long = "vnc-listen-address")]
-    pub vnc_listen_addresses: Vec<SocketAddr>,
 
     /// Enable native display output. This requires some form of graphical system (so will probably not work on your
     /// server).
@@ -91,69 +67,24 @@ pub struct CliArgs {
     #[clap(long)]
     pub native_display: bool,
 
-    /// Enable the NDI source. Set the source name with --ndi-source-name.
-    #[cfg(feature = "ndi")]
-    #[clap(long)]
-    pub ndi: bool,
-    /// Set the readable NDI source name. NDI output is not enabled unless you specify --ndi.
-    #[cfg(feature = "ndi")]
-    #[clap(long, default_value = "breakwater canvas")]
-    pub ndi_source_name: String,
-
-    /// Specify a view port to display the canvas or a certain part of it. Format: `<offset_x>x<offset_y>,<width>x<height>`.
-    /// Might be specified multiple times for more than one viewport. Useful for multi-projector setups.
-    /// Defaults to display the entire canvas.
-    /// Implies --native-display.
-    #[cfg(feature = "egui")]
-    #[clap(long)]
-    pub viewport: Vec<crate::sinks::egui::ViewportConfig>,
-
-    /// Specify one or more pixelflut endpoints to display.
-    #[cfg(feature = "egui")]
-    #[clap(long)]
-    pub advertised_endpoints: Vec<String>,
-
-    /// Provide a path to a dylib containing a custom egui overlay.
-    /// Implies --native-display.
-    //
-    // Qualifying import here to avoid feature-specific imports
-    #[cfg(feature = "egui")]
-    #[clap(long)]
-    pub ui: Option<std::path::PathBuf>,
-
     /// Create (or use an existing) shared memory region for the framebuffer.
     /// This enables other applications to read and write Pixel values to the framebuffer or can be
     /// used to persist the canvas across restarts.
     #[clap(long)]
     pub shared_memory_name: Option<String>,
-}
 
-impl CliArgs {
-    /// Checks that at most one IP per version (v4/v6) is configured.
-    /// Returns the (optional) v4 address and (optional) v6 address.
+    #[clap(flatten)]
+    pub ffmpeg_sink: crate::sinks::ffmpeg::FfmpegSinkCliArgs,
+
+    #[cfg(feature = "egui")]
+    #[clap(flatten)]
+    pub egui_sink: crate::sinks::egui::EguiSinkCliArgs,
+
+    #[cfg(feature = "ndi")]
+    #[clap(flatten)]
+    pub ndi_sink: crate::sinks::ndi::NdiSinkCliArgs,
+
     #[cfg(feature = "vnc")]
-    pub fn get_vnc_listen_addresses(
-        &self,
-    ) -> eyre::Result<(Option<&SocketAddrV4>, Option<&SocketAddrV6>)> {
-        self.vnc_listen_addresses
-            .iter()
-            .try_fold((None, None), |(v4, v6), addr| match addr {
-                SocketAddr::V4(new) => {
-                    // Fail if an IPv4 was already encountered
-                    ensure!(
-                        v4.is_none(),
-                        "You can only specify one IPv4 VNC listen address"
-                    );
-                    Ok((Some(new), v6))
-                }
-                SocketAddr::V6(new) => {
-                    // Fail if an IPv6 was already encountered
-                    ensure!(
-                        v6.is_none(),
-                        "You can only specify one IPv6 VNC listen address"
-                    );
-                    Ok((v4, Some(new)))
-                }
-            })
-    }
+    #[clap(flatten)]
+    pub vnc_sink: crate::sinks::vnc::VncSinkCliArgs,
 }

--- a/breakwater/src/main.rs
+++ b/breakwater/src/main.rs
@@ -41,15 +41,6 @@ async fn main() -> eyre::Result<()> {
 
     let args = CliArgs::parse();
 
-    // Give the user quick feedback on invalid VNC arguments
-    #[cfg(feature = "vnc")]
-    if let Err(e) = args.get_vnc_listen_addresses() {
-        use clap::CommandFactory;
-        let mut cmd = <CliArgs as CommandFactory>::command();
-        // Displays error in the standard 'clap' format and exits
-        cmd.error(clap::error::ErrorKind::InvalidValue, e).exit();
-    }
-
     // Not using dynamic dispatch here for performance reasons
     let fb = Arc::new(
         SharedMemoryFrameBuffer::new(args.width, args.height, args.shared_memory_name.as_deref())
@@ -128,12 +119,13 @@ async fn main() -> eyre::Result<()> {
 
         if let Some(vnc_sink) = VncSink::new(
             fb.clone(),
-            &args,
+            &args.vnc_sink,
+            args.fps,
+            &args.text,
             statistics_tx.clone(),
             statistics_information_rx.resubscribe(),
             terminate_signal_rx.resubscribe(),
         )
-        .await
         .context("failed to create vnc sink")?
         {
             display_sinks.push(Box::new(vnc_sink));
@@ -146,12 +138,10 @@ async fn main() -> eyre::Result<()> {
 
         if let Some(ndi_sink) = NdiSink::new(
             fb.clone(),
-            &args,
-            statistics_tx.clone(),
-            statistics_information_rx.resubscribe(),
+            &args.ndi_sink,
+            args.fps,
             terminate_signal_rx.resubscribe(),
         )
-        .await
         .context("failed to create ndi sink")?
         {
             display_sinks.push(Box::new(ndi_sink));
@@ -161,12 +151,10 @@ async fn main() -> eyre::Result<()> {
     let mut ffmpeg_thread_present = false;
     if let Some(ffmpeg_sink) = FfmpegSink::new(
         fb.clone(),
-        &args,
-        statistics_tx.clone(),
-        statistics_information_rx.resubscribe(),
+        &args.ffmpeg_sink,
+        args.fps,
         terminate_signal_rx.resubscribe(),
     )
-    .await
     .context("failed to create ffmpeg sink")?
     {
         display_sinks.push(Box::new(ffmpeg_sink));
@@ -187,12 +175,12 @@ async fn main() -> eyre::Result<()> {
 
         match EguiSink::new(
             fb.clone(),
-            &args,
-            statistics_tx.clone(),
+            &args.egui_sink,
+            &args.listen_addresses,
+            args.native_display,
             statistics_information_rx.resubscribe(),
             terminate_signal_rx.resubscribe(),
         )
-        .await
         .context("failed to create egui sink")?
         {
             Some(mut egui_sink) => {

--- a/breakwater/src/sinks/egui/mod.rs
+++ b/breakwater/src/sinks/egui/mod.rs
@@ -1,11 +1,11 @@
-use std::{fmt::Display, str::FromStr, sync::Arc};
+use std::{fmt::Display, net::SocketAddr, str::FromStr, sync::Arc};
 
 use async_trait::async_trait;
 use breakwater_parser::FrameBuffer;
 use color_eyre::eyre::{self, Context};
 use dynamic_overlay::UiOverlay;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::broadcast;
 use tracing::instrument;
 
 use super::DisplaySink;
@@ -14,6 +14,28 @@ use crate::statistics::StatisticsInformationEvent;
 mod canvas_renderer;
 mod dynamic_overlay;
 mod view;
+
+#[derive(Clone, Debug, clap::Parser)]
+#[command(next_help_heading = "egui options")]
+pub struct EguiSinkCliArgs {
+    /// Specify a view port to display the canvas or a certain part of it. Format: `<offset_x>x<offset_y>,<width>x<height>`.
+    /// Might be specified multiple times for more than one viewport. Useful for multi-projector setups.
+    /// Defaults to display the entire canvas.
+    /// Implies --native-display.
+    #[clap(long)]
+    pub viewport: Vec<crate::sinks::egui::ViewportConfig>,
+
+    /// Specify one or more pixelflut endpoints to display.
+    #[clap(long)]
+    pub advertised_endpoints: Vec<String>,
+
+    /// Provide a path to a dylib containing a custom egui overlay.
+    /// Implies --native-display.
+    //
+    // Qualifying import here to avoid feature-specific imports
+    #[clap(long)]
+    pub ui: Option<std::path::PathBuf>,
+}
 
 /// Describes the part of the framebuffer that the corresponding viewport will display.
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
@@ -67,25 +89,22 @@ pub struct EguiSink<FB: FrameBuffer> {
     ui_overlay: Arc<UiOverlay>,
 }
 
-#[async_trait]
-impl<FB: FrameBuffer + Send + Sync + 'static> DisplaySink<FB> for EguiSink<FB> {
+impl<FB: FrameBuffer + Send + Sync + 'static> EguiSink<FB> {
     /// This function can return [`None`] in case this sink is not configured (by looking at the `cli_args`).
     #[instrument(skip_all, err)]
-    async fn new(
+    pub fn new(
         fb: Arc<FB>,
-        cli_args: &crate::cli_args::CliArgs,
-        _statistics_tx: mpsc::Sender<crate::statistics::StatisticsEvent>,
+        EguiSinkCliArgs {
+            viewport,
+            advertised_endpoints,
+            ui,
+        }: &EguiSinkCliArgs,
+        listen_addresses: &[SocketAddr],
+        native_display: bool,
         statistics_information_rx: broadcast::Receiver<StatisticsInformationEvent>,
         terminate_signal_rx: broadcast::Receiver<()>,
-    ) -> eyre::Result<Option<Self>>
-    where
-        Self: Sized,
-    {
-        let viewports = match (
-            cli_args.viewport.as_slice(),
-            cli_args.native_display,
-            cli_args.ui.as_ref(),
-        ) {
+    ) -> eyre::Result<Option<Self>> {
+        let viewports = match (viewport.as_slice(), native_display, ui.as_ref()) {
             (vp, _, _) if !vp.is_empty() => Vec::from(vp),
             ([], _, Some(_)) | ([], true, _) => vec![ViewportConfig {
                 x: 0,
@@ -97,17 +116,17 @@ impl<FB: FrameBuffer + Send + Sync + 'static> DisplaySink<FB> for EguiSink<FB> {
         };
 
         let ui_overlay = Arc::new({
-            if let Some(ui) = cli_args.ui.as_ref() {
+            if let Some(ui) = ui.as_ref() {
                 dynamic_overlay::load_and_check(ui).context("failed to load dynamic overlay")?
             } else {
                 UiOverlay::BuiltIn
             }
         });
 
-        let advertised_endpoints = if cli_args.advertised_endpoints.is_empty() {
+        let advertised_endpoints = if advertised_endpoints.is_empty() {
             // In case no advertised endpoints to display are given, we calculate the most likely
             // endpoint(s) to display.
-            match &cli_args.listen_addresses[..] {
+            match listen_addresses[..] {
                 // No listeners given, so also no endpoints to advertise
                 [] => vec![],
                 // In case of a single listener we get the local IPs (v4 + v6) and concat them with
@@ -122,10 +141,12 @@ impl<FB: FrameBuffer + Send + Sync + 'static> DisplaySink<FB> for EguiSink<FB> {
                         .collect()
                 }
                 // If multiple listeners are used it's complicated, so we just print them
-                multiple_listeners => multiple_listeners.iter().map(ToString::to_string).collect(),
+                ref multiple_listeners => {
+                    multiple_listeners.iter().map(ToString::to_string).collect()
+                }
             }
         } else {
-            cli_args.advertised_endpoints.clone()
+            advertised_endpoints.clone()
         };
 
         Ok(Some(Self {
@@ -137,7 +158,10 @@ impl<FB: FrameBuffer + Send + Sync + 'static> DisplaySink<FB> for EguiSink<FB> {
             ui_overlay,
         }))
     }
+}
 
+#[async_trait]
+impl<FB: FrameBuffer + Send + Sync + 'static> DisplaySink<FB> for EguiSink<FB> {
     /// This should only run on the main thread
     #[instrument(skip(self), err)]
     async fn run(&mut self) -> eyre::Result<()> {

--- a/breakwater/src/sinks/ffmpeg.rs
+++ b/breakwater/src/sinks/ffmpeg.rs
@@ -4,48 +4,53 @@ use async_trait::async_trait;
 use breakwater_parser::FrameBuffer;
 use chrono::Local;
 use color_eyre::eyre::{self, Context};
-use tokio::{
-    io::AsyncWriteExt,
-    process::Command,
-    sync::{broadcast, mpsc},
-    time,
-};
+use tokio::{io::AsyncWriteExt, process::Command, sync::broadcast, time};
 use tracing::instrument;
 
-use crate::{sinks::DisplaySink, statistics::StatisticsInformationEvent};
+use crate::sinks::DisplaySink;
 
-pub struct FfmpegSink<FB: FrameBuffer> {
-    fb: Arc<FB>,
-    terminate_signal_rx: broadcast::Receiver<()>,
+#[derive(Clone, Debug, clap::Parser)]
+#[command(next_help_heading = "ffmpeg options")]
+pub struct FfmpegSinkCliArgs {
+    /// Enable rtmp streaming to configured address, e.g. `rtmp://127.0.0.1:1935/live/test`
+    #[clap(long)]
+    pub rtmp_address: Option<String>,
 
-    rtmp_address: Option<String>,
-    video_save_folder: Option<String>,
-    fps: u32,
+    /// Enable dump of video stream into file. File location will be `<VIDEO_SAVE_FOLDER>/pixelflut_dump_{timestamp}.mp4`
+    #[clap(long)]
+    pub video_save_folder: Option<String>,
 }
 
-#[async_trait]
-impl<FB: FrameBuffer + Sync + Send> DisplaySink<FB> for FfmpegSink<FB> {
+pub struct FfmpegSink<FB: FrameBuffer> {
+    cli_args: FfmpegSinkCliArgs,
+    fb: Arc<FB>,
+    fps: u32,
+    terminate_signal_rx: broadcast::Receiver<()>,
+}
+
+impl<FB: FrameBuffer + Sync + Send> FfmpegSink<FB> {
     #[instrument(skip_all, err)]
-    async fn new(
+    pub fn new(
         fb: Arc<FB>,
-        cli_args: &crate::cli_args::CliArgs,
-        _statistics_tx: mpsc::Sender<crate::statistics::StatisticsEvent>,
-        _statistics_information_rx: broadcast::Receiver<StatisticsInformationEvent>,
+        cli_args: &FfmpegSinkCliArgs,
+        fps: u32,
         terminate_signal_rx: broadcast::Receiver<()>,
     ) -> eyre::Result<Option<Self>> {
         if cli_args.rtmp_address.is_some() || cli_args.video_save_folder.is_some() {
             Ok(Some(Self {
+                cli_args: cli_args.to_owned(),
                 fb,
+                fps,
                 terminate_signal_rx,
-                rtmp_address: cli_args.rtmp_address.clone(),
-                video_save_folder: cli_args.video_save_folder.clone(),
-                fps: cli_args.fps,
             }))
         } else {
             Ok(None)
         }
     }
+}
 
+#[async_trait]
+impl<FB: FrameBuffer + Sync + Send> DisplaySink<FB> for FfmpegSink<FB> {
     #[instrument(skip(self), err)]
     async fn run(&mut self) -> eyre::Result<()> {
         let mut ffmpeg_args: Vec<String> = self
@@ -54,9 +59,9 @@ impl<FB: FrameBuffer + Sync + Send> DisplaySink<FB> for FfmpegSink<FB> {
             .flat_map(|(arg, value)| [format!("-{arg}"), value])
             .collect();
 
-        match &self.rtmp_address {
+        match &self.cli_args.rtmp_address {
             Some(rtmp_address) => {
-                if let Some(video_save_folder) = &self.video_save_folder {
+                if let Some(video_save_folder) = &self.cli_args.video_save_folder {
                     // Write to rtmp and file
                     ffmpeg_args.extend(
                         self.ffmpeg_rtmp_sink_args()
@@ -92,7 +97,7 @@ impl<FB: FrameBuffer + Sync + Send> DisplaySink<FB> for FfmpegSink<FB> {
                     ffmpeg_args.extend(["-f".to_string(), "flv".to_string(), rtmp_address.clone()]);
                 }
             }
-            None => match &self.video_save_folder {
+            None => match &self.cli_args.video_save_folder {
                 // Only write to file
                 Some(video_save_folder) => {
                     ffmpeg_args.extend([Self::video_file(video_save_folder)]);

--- a/breakwater/src/sinks/mod.rs
+++ b/breakwater/src/sinks/mod.rs
@@ -1,13 +1,5 @@
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use color_eyre::eyre;
-use tokio::sync::{broadcast, mpsc};
-
-use crate::{
-    cli_args::CliArgs,
-    statistics::{StatisticsEvent, StatisticsInformationEvent},
-};
 
 #[cfg(feature = "egui")]
 pub mod egui;
@@ -23,16 +15,5 @@ pub mod vnc;
 // functions as dyn Trait, so we still need to use async_trait here.
 #[async_trait]
 pub trait DisplaySink<FB> {
-    /// This function can return [`None`] in case this sink is not configured (by looking at the `cli_args`).
-    async fn new(
-        fb: Arc<FB>,
-        cli_args: &CliArgs,
-        statistics_tx: mpsc::Sender<StatisticsEvent>,
-        statistics_information_rx: broadcast::Receiver<StatisticsInformationEvent>,
-        terminate_signal_rx: broadcast::Receiver<()>,
-    ) -> eyre::Result<Option<Self>>
-    where
-        Self: Sized;
-
     async fn run(&mut self) -> eyre::Result<()>;
 }

--- a/breakwater/src/sinks/native_display.rs
+++ b/breakwater/src/sinks/native_display.rs
@@ -31,13 +31,11 @@ pub struct NativeDisplaySink<FB: FrameBuffer> {
 }
 
 #[async_trait]
-impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NativeDisplaySink<FB> {
+impl<FB: FrameBuffer + Sync + Send + 'static> NativeDisplaySink<FB> {
     #[instrument(skip_all, err)]
-    async fn new(
+    pub fn new(
         fb: Arc<FB>,
         cli_args: &CliArgs,
-        _statistics_tx: mpsc::Sender<StatisticsEvent>,
-        _statistics_information_rx: broadcast::Receiver<StatisticsInformationEvent>,
         terminate_signal_rx: broadcast::Receiver<()>,
     ) -> eyre::Result<Option<Self>> {
         if !cli_args.native_display {
@@ -50,7 +48,10 @@ impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NativeDisplayS
             surface: None,
         }))
     }
+}
 
+#[async_trait]
+impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NativeDisplaySink<FB> {
     #[instrument(skip(self), err)]
     async fn run(&mut self) -> eyre::Result<()> {
         let fb_clone = self.fb.clone();

--- a/breakwater/src/sinks/ndi.rs
+++ b/breakwater/src/sinks/ndi.rs
@@ -12,34 +12,43 @@ use ndi_sdk_sys::{
     sdk,
     sender::{NDISender, NDISenderBuilder},
 };
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::broadcast;
 use tracing::{error, info, instrument, trace};
 
-use crate::{
-    cli_args::CliArgs,
-    sinks::DisplaySink,
-    statistics::{StatisticsEvent, StatisticsInformationEvent},
-};
+use crate::sinks::DisplaySink;
+
+#[derive(Clone, Debug, clap::Parser)]
+#[command(next_help_heading = "NDI options options")]
+pub struct NdiSinkCliArgs {
+    /// Enable the NDI source. Set the source name with --ndi-source-name.
+    #[clap(long)]
+    pub ndi: bool,
+
+    /// Set the readable NDI source name. NDI output is not enabled unless you specify --ndi.
+    #[clap(long, default_value = "breakwater canvas")]
+    pub ndi_source_name: String,
+}
 
 pub struct NdiSink<FB: FrameBuffer> {
     fb: Arc<FB>,
     terminate_signal_rx: broadcast::Receiver<()>,
-    target_fps: u32,
+    fps: u32,
 
     source: Arc<NDISender>,
 }
 
-#[async_trait]
-impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NdiSink<FB> {
+impl<FB: FrameBuffer + Sync + Send + 'static> NdiSink<FB> {
     #[instrument(skip_all, err)]
-    async fn new(
+    pub fn new(
         fb: Arc<FB>,
-        cli_args: &CliArgs,
-        _statistics_tx: mpsc::Sender<StatisticsEvent>,
-        _statistics_information_rx: broadcast::Receiver<StatisticsInformationEvent>,
+        NdiSinkCliArgs {
+            ndi,
+            ndi_source_name,
+        }: &NdiSinkCliArgs,
+        fps: u32,
         terminate_signal_rx: broadcast::Receiver<()>,
     ) -> eyre::Result<Option<Self>> {
-        if !cli_args.ndi {
+        if !ndi {
             return Ok(None);
         }
 
@@ -50,7 +59,7 @@ impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NdiSink<FB> {
         sdk::initialize().context("failed to initialize NDI SDK")?;
 
         let source = NDISenderBuilder::new()
-            .name(&cli_args.ndi_source_name)?
+            .name(ndi_source_name)?
             .clock_video(true)
             .build()
             .context("failed to build NDI sender")?;
@@ -68,16 +77,19 @@ impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NdiSink<FB> {
             fb,
             terminate_signal_rx,
             source: Arc::new(source),
-            target_fps: cli_args.fps,
+            fps,
         }))
     }
+}
 
+#[async_trait]
+impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NdiSink<FB> {
     #[instrument(skip(self), err)]
     async fn run(&mut self) -> eyre::Result<()> {
         let fb = self.fb.clone();
         let mut terminate_signal_rx = self.terminate_signal_rx.resubscribe();
         let source = self.source.clone();
-        let target_fps = self.target_fps;
+        let fps = i32::try_from(self.fps).context("fps too high to fit in i32")?;
 
         tokio::task::spawn_blocking(move || {
             let mut frame = VideoFrame::new();
@@ -88,7 +100,7 @@ impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NdiSink<FB> {
             // The framebuffer is "technically" RGBA, but the alpha values are always zero.
             // If we were to set RGBA here, the image would be entirely black :)
             frame.set_four_cc(FourCCVideo::RGBX)?;
-            frame.set_frame_rate((target_fps as i32).into());
+            frame.set_frame_rate(fps.into());
             frame
                 .try_alloc()
                 .context("failed to allocate NDI framebuffer")?;

--- a/breakwater/src/sinks/ndi.rs
+++ b/breakwater/src/sinks/ndi.rs
@@ -18,7 +18,7 @@ use tracing::{error, info, instrument, trace};
 use crate::sinks::DisplaySink;
 
 #[derive(Clone, Debug, clap::Parser)]
-#[command(next_help_heading = "NDI options options")]
+#[command(next_help_heading = "NDI options")]
 pub struct NdiSinkCliArgs {
     /// Enable the NDI source. Set the source name with --ndi-source-name.
     #[clap(long)]

--- a/breakwater/src/sinks/vnc.rs
+++ b/breakwater/src/sinks/vnc.rs
@@ -1,9 +1,15 @@
 use core::slice;
-use std::{ffi::CString, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    ffi::CString,
+    net::{SocketAddr, SocketAddrV4, SocketAddrV6},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use breakwater_parser::{FB_BYTES_PER_PIXEL, FrameBuffer};
-use color_eyre::eyre::{self, Context, ContextCompat};
+use color_eyre::eyre::{self, Context, ContextCompat, ensure};
 use number_prefix::NumberPrefix;
 use rusttype::{Font, Scale, point};
 use tokio::{
@@ -16,7 +22,6 @@ use vncserver::{
 };
 
 use crate::{
-    cli_args::CliArgs,
     sinks::DisplaySink,
     statistics::{
         STATISTICS_INFO_RECV_ERR, STATISTICS_SEND_ERR, StatisticsEvent, StatisticsInformationEvent,
@@ -24,6 +29,21 @@ use crate::{
 };
 
 const STATS_HEIGHT: usize = 35;
+
+#[derive(Clone, Debug, clap::Parser)]
+#[command(next_help_heading = "VNC options")]
+pub struct VncSinkCliArgs {
+    /// VNC server listen address to bind to (multiple can be specified).
+    /// Only one address of each IP version can be specified
+    #[clap(long = "vnc-listen-address")]
+    pub vnc_listen_addresses: Vec<SocketAddr>,
+
+    /// The font used to render the text on the screen.
+    /// Should be a ttf file.
+    /// If you use the default value a copy that ships with breakwater will be used - no need to download and provide the font.
+    #[clap(long, default_value = "Arial.ttf")]
+    pub font: String,
+}
 
 // Sorry! Help needed :)
 unsafe impl<FB: FrameBuffer> Send for VncSink<'_, FB> {}
@@ -35,34 +55,38 @@ pub struct VncSink<'a, FB: FrameBuffer> {
     terminate_signal_rx: broadcast::Receiver<()>,
 
     screen: RfbScreenInfoPtr,
-    target_fps: u32,
+    fps: u32,
     text: String,
     font: Font<'a>,
 }
 
-#[async_trait]
-impl<FB: FrameBuffer + Sync + Send> DisplaySink<FB> for VncSink<'_, FB> {
-    async fn new(
+impl<FB: FrameBuffer + Sync + Send> VncSink<'_, FB> {
+    pub fn new(
         fb: Arc<FB>,
-        cli_args: &CliArgs,
+        VncSinkCliArgs {
+            vnc_listen_addresses,
+            font,
+        }: &VncSinkCliArgs,
+        fps: u32,
+        text: &str,
         statistics_tx: mpsc::Sender<StatisticsEvent>,
         statistics_information_rx: broadcast::Receiver<StatisticsInformationEvent>,
         terminate_signal_rx: broadcast::Receiver<()>,
     ) -> eyre::Result<Option<Self>> {
-        if cli_args.vnc_listen_addresses.is_empty() {
+        if vnc_listen_addresses.is_empty() {
             tracing::debug!("VNC sink not enabled as no vnc addresses are specified");
             return Ok(None);
         }
 
         // We ship our own copy of Arial.ttf, so that users don't need to download and provide it
-        let font = if cli_args.font.as_str() == "Arial.ttf" {
+        let font = if font.as_str() == "Arial.ttf" {
             let font_bytes = include_bytes!("../../../Arial.ttf");
             Font::try_from_bytes(font_bytes).context("failed to load default font")?
         } else {
-            let font_bytes = std::fs::read(&cli_args.font)
-                .with_context(|| format!("failed to read font from file {}", cli_args.font))?;
+            let font_bytes = std::fs::read(font)
+                .with_context(|| format!("failed to read font from file {font}"))?;
             Font::try_from_vec(font_bytes)
-                .with_context(|| format!("failed to construct font from file {}", cli_args.font))?
+                .with_context(|| format!("failed to construct font from file {font}"))?
         };
 
         let screen = rfb_get_screen(fb.get_width() as i32, fb.get_height() as i32, 8, 3, 4);
@@ -77,7 +101,7 @@ impl<FB: FrameBuffer + Sync + Send> DisplaySink<FB> for VncSink<'_, FB> {
             (*screen).ipv6port = -1;
         }
 
-        let (v4, v6) = cli_args.get_vnc_listen_addresses()?;
+        let (v4, v6) = vnc_listen_addresses_v4_v6(vnc_listen_addresses)?;
 
         if let Some(v4) = v4 {
             unsafe {
@@ -112,12 +136,15 @@ impl<FB: FrameBuffer + Sync + Send> DisplaySink<FB> for VncSink<'_, FB> {
             statistics_information_rx,
             terminate_signal_rx,
             screen,
-            target_fps: cli_args.fps,
-            text: cli_args.text.clone(),
+            fps,
+            text: text.to_owned(),
             font,
         }))
     }
+}
 
+#[async_trait]
+impl<FB: FrameBuffer + Sync + Send> DisplaySink<FB> for VncSink<'_, FB> {
     async fn run(&mut self) -> eyre::Result<()> {
         let vnc_fb_slice: &mut [u8] = unsafe {
             slice::from_raw_parts_mut(
@@ -130,9 +157,7 @@ impl<FB: FrameBuffer + Sync + Send> DisplaySink<FB> for VncSink<'_, FB> {
         let height_up_to_stats_text = self.fb.get_height() - STATS_HEIGHT - 1;
         let fb_size_up_to_stats_text = self.fb.get_width() * height_up_to_stats_text;
 
-        let mut interval = time::interval(Duration::from_micros(
-            1_000_000 / u64::from(self.target_fps),
-        ));
+        let mut interval = time::interval(Duration::from_micros(1_000_000 / u64::from(self.fps)));
         loop {
             if self.terminate_signal_rx.try_recv().is_ok() {
                 return Ok(());
@@ -263,4 +288,29 @@ fn format(value: f64) -> String {
         NumberPrefix::Prefixed(prefix, n) => format!("{n:.1}{prefix}"),
         NumberPrefix::Standalone(n) => format!("{n}"),
     }
+}
+
+/// Splits VNC listen addresses into at most one IPv4 and one IPv6 address (libvncserver listens on
+/// one of each). Errors if more than one of either version is given.
+pub fn vnc_listen_addresses_v4_v6(
+    addresses: &[SocketAddr],
+) -> eyre::Result<(Option<&SocketAddrV4>, Option<&SocketAddrV6>)> {
+    addresses
+        .iter()
+        .try_fold((None, None), |(v4, v6), addr| match addr {
+            SocketAddr::V4(addr) => {
+                ensure!(
+                    v4.is_none(),
+                    "You can only specify one IPv4 VNC listen address"
+                );
+                Ok((Some(addr), v6))
+            }
+            SocketAddr::V6(addr) => {
+                ensure!(
+                    v6.is_none(),
+                    "You can only specify one IPv6 VNC listen address"
+                );
+                Ok((v4, Some(addr)))
+            }
+        })
 }


### PR DESCRIPTION
As it now doesn't take the **entire** breakwater CLI args, we can actually use the sinks somewhere else