### PR TITLE
 chore!: Refactor CLI arguments 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,16 +195,10 @@ jobs:
           command: build
           # ndi-sdk-sys (behind the ndi features) only supports Linux x86 (no aarch64) so far.
           # We already run the tests on x86 Linux with all features above.
-          args: --target=${{ matrix.target }} --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display,vnc
+          args: --target=${{ matrix.target }} --features alpha,binary-set-pixel,binary-sync-pixels,egui,winit,vnc
       # I couldn't get pkg-config to work on macOS and Windows, so we omit the vnc and ndi feature
       - if: runner.os == 'macOS' || runner.os == 'Windows'
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target=${{ matrix.target }} --no-default-features --features alpha,binary-set-pixel,binary-sync-pixels,egui,native-display
-      # Most of the native-display functionality is not compiled in if egui is also enabled, so we need to check it separately.
-      - name: Build with feature native-display but without egui
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target=${{ matrix.target }} --no-default-features --features native-display
+          args: --target=${{ matrix.target }} --no-default-features --features alpha,binary-set-pixel,binary-sync-pixels,egui,winit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ All notable changes to this project will be documented in this file.
   - Rename all existing sink-specific-options to start with <sinkname>. This was notably not the case for ffmpeg, some vnc options, and egui.
   - Made it an error to specify options for sinks that are not enabled. In the same vein, obviously some sinks require certain options to be specified (just like now, except those options currently also usually enable the sink in the first place).
   - In `--help`, the options are now grouped by sink using a standard header.
-  - E.g. instead of `` now use ``
+  - Some typical usage pattern examples:
+    - Instead of `--native-display` now use `--enable-sink egui`
+    - Instead of `--vnc-listen-address 0.0.0.0:5900 --text foo` now use `--enable-sink vnc --vnc-listen-address 0.0.0.0:5900 --vnc-text foo`
 - BREAKING: The default sink feature set has changed: By default we now only enable `winit` and `egui` ([#89]).<br>
   They require a graphical environment, but most people getting started with breakwater will likely do that on a desktop, servers admins generally know what they are doing (tm).
   Once we have a webserver we might want to re-visit that choice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- BREAKING: Refactor CLI arguments ([#89]).
+  - Add a single option `-s/--enable-sink <sinkname>`, which replaces all the other sink-enabling flags (like --ndi) and can be specified multiple times (once per desired sink).
+    Each sink is disabled by default, but breakwater warns if none is enabled.
+  - Rename all existing sink-specific-options to start with <sinkname>. This was notably not the case for ffmpeg, some vnc options, and egui.
+  - Made it an error to specify options for sinks that are not enabled. In the same vein, obviously some sinks require certain options to be specified (just like now, except those options currently also usually enable the sink in the first place).
+  - In `--help`, the options are now grouped by sink using a standard header.
+  - E.g. instead of `` now use ``
+- BREAKING: The default sink feature set has changed: By default we now only enable `winit` and `egui` ([#89]).<br>
+  They require a graphical environment, but most people getting started with breakwater will likely do that on a desktop, servers admins generally know what they are doing (tm).
+  Once we have a webserver we might want to re-visit that choice.
+
+[#89]: https://github.com/sbernauer/breakwater/pull/89
+
 ## [0.21.0] - 2026-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It claims to be the fastest Pixelflut server in existence - at least at the time
 # Features
 1. Accepts Pixelflut commands
 2. Many possible outputs:
-  - Start a native display window in your graphical environment
+  - Start a native display window in your graphical environment (using either winit or egui)
   - Start a VNC server so that everybody can watch
   - Stream to an RTMP sink, so that you can e.g. directly live-stream into Twitch or YouTube
   - Provide an [NDI](https://ndi.video) source
@@ -76,10 +76,8 @@ Options:
           Frames per second the server should aim for [default: 30]
       --network-buffer-size <NETWORK_BUFFER_SIZE>
           The size in bytes of the network buffer used for each open TCP connection. Please use at least 64 KB (64_000 bytes) [default: 262144]
-  -t, --text <TEXT>
-          Text to display on the screen [default: "Pixelflut server (breakwater)"]
   -p, --prometheus-listen-address <PROMETHEUS_LISTEN_ADDRESS>
-          Listen address the prometheus exporter should listen on [default: [::]:9100]
+          Listen address the Prometheus exporter should listen on [default: [::]:9100]
       --statistics-save-file <STATISTICS_SAVE_FILE>
           Save file where statistics are periodically saved. The save file will be read during startup and statistics are restored. To reset the statistics simply remove the file [default: statistics.json]
       --statistics-save-interval-s <STATISTICS_SAVE_INTERVAL_S>
@@ -88,39 +86,38 @@ Options:
           Disable periodical saving of statistics into save file
   -c, --connections-per-ip <CONNECTIONS_PER_IP>
           Allow only a certain number of connections per ip address
-      --native-display
-          Enable native display output. This requires some form of graphical system (so will probably not work on your server)
       --shared-memory-name <SHARED_MEMORY_NAME>
           Create (or use an existing) shared memory region for the framebuffer. This enables other applications to read and write Pixel values to the framebuffer or can be used to persist the canvas across restarts
+  -s, --enable-sink <ENABLED_SINKS>
+          Enable an arbitrary number of sinks (argument can be repeated). The availability of sinks depends on the enabled features [possible values: ffmpeg, egui, winit, vnc, ndi]
   -h, --help
           Print help
   -V, --version
           Print version
 
 ffmpeg sink options:
-      --rtmp-address <RTMP_ADDRESS>
+      --ffmpeg-rtmp-address <RTMP_ADDRESS>
           Enable rtmp streaming to configured address, e.g. `rtmp://127.0.0.1:1935/live/test`
-      --video-save-folder <VIDEO_SAVE_FOLDER>
+      --ffmpeg-video-save-folder <VIDEO_SAVE_FOLDER>
           Enable dump of video stream into file. File location will be `<VIDEO_SAVE_FOLDER>/pixelflut_dump_{timestamp}.mp4`
 
 egui sink options:
-      --viewport <VIEWPORT>
-          Specify a view port to display the canvas or a certain part of it. Format: `<offset_x>x<offset_y>,<width>x<height>`. Might be specified multiple times for more than one viewport. Useful for multi-projector setups. Defaults to display the entire canvas. Implies --native-display
-      --advertised-endpoints <ADVERTISED_ENDPOINTS>
+      --egui-viewport <VIEWPORTS>
+          Specify a view port to display the canvas or a certain part of it. Format: `<offset_x>x<offset_y>,<width>x<height>`. Might be specified multiple times for more than one viewport. Useful for multi-projector setups. Defaults to display the entire canvas
+      --egui-advertised-endpoint <ADVERTISED_ENDPOINTS>
           Specify one or more pixelflut endpoints to display
-      --ui <UI>
-          Provide a path to a dylib containing a custom egui overlay. Implies --native-display
+      --egui-ui <UI>
+          Provide a path to a dylib containing a custom egui overlay
 
 NDI sink options:
-      --ndi
-          Enable the NDI source
-      --ndi-source-name <NDI_SOURCE_NAME>
-          Readable NDI source name. Requires --ndi to be set [default: "breakwater canvas"]
+      --ndi-source-name <SOURCE_NAME>  Readable NDI source name [default: "Pixelflut server (breakwater)"]
 
 VNC sink options:
       --vnc-listen-address <VNC_LISTEN_ADDRESSES>
           VNC server listen address to bind to (multiple can be specified). Only one address of each IP version can be specified
-      --font <FONT>
+      --vnc-text <TEXT>
+          Text to display on the screen [default: "Pixelflut server (breakwater)"]
+      --vnc-font <FONT>
           The font used to render the text on the screen. Should be a ttf file. If you use the default value a copy that ships with breakwater will be used - no need to download and provide the font [default: Arial.ttf]
 ```
 </details>
@@ -134,14 +131,14 @@ You can get the list of available features by looking at the [Cargo.toml](Cargo.
 As of writing the following features are supported:
 
 * `egui` (enabled by default): Enables an advanced customizable graphical frontend on your local system. Please note that this requires a graphical environment.
-* `native-display` (disabled by default): Enables a minimalist graphical window on your local system. Please note that this requires a graphical environment.
+* `winit` (enabled by default): Enables a minimalist graphical window on your local system. Please note that this requires a graphical environment.
 * `ndi` (disabled by default): Enables NDI video streaming. This requires the proprietary NDI SDK to be installed, see below.
-* `vnc` (enabled by default): Starts a VNC server, where users can connect to. Needs `libvncserver-dev` to be installed. Please note that the VNC server offers basically no latency, but consumes quite some CPU.
+* `vnc` (disabled by default): Starts a VNC server, where users can connect to. Needs `libvncserver-dev` to be installed. Please note that the VNC server offers basically no latency, but consumes quite some CPU.
 * `alpha` (disabled by default): Respect alpha values during `PX` commands. Disabled by default as this can cause performance degradation.
 * `binary-set-pixel` (disabled by default): Allows use of the `PB` command.
 * `binary-sync-pixels`(disabled by default): Allows use of the `PXMULTI` command.
 
-To e.g. turn the VNC server off, build with
+To e.g. turn the local display windows off, build with
 
 ```bash
 cargo run --release --no-default-features
@@ -150,7 +147,7 @@ cargo run --release --no-default-features
 Enable (any number of) desired features with
 
 ```bash
-cargo run --release --features vnc,native-display,alpha
+cargo run --release --features vnc,alpha
 ```
 
 ## NDI

--- a/breakwater/Cargo.toml
+++ b/breakwater/Cargo.toml
@@ -28,10 +28,10 @@ libloading = { workspace = true, optional = true }
 local-ip-address.workspace = true
 memadvise.workspace = true
 ndi-sdk-sys = { workspace = true, optional = true }
-number_prefix.workspace = true
+number_prefix = { workspace = true, optional = true }
 page_size.workspace = true
 prometheus_exporter.workspace = true
-rusttype.workspace = true
+rusttype = { workspace = true, optional = true }
 serde_json.workspace = true
 serde.workspace = true
 simple_moving_average.workspace = true
@@ -59,7 +59,7 @@ binary-set-pixel = ["breakwater-parser/binary-set-pixel"]
 binary-sync-pixels = ["breakwater-parser/binary-sync-pixels"]
 egui = ["dep:breakwater-egui-overlay", "dep:bytemuck", "dep:eframe", "dep:egui", "dep:libloading"]
 winit = ["dep:softbuffer", "dep:winit"]
-vnc = ["dep:vncserver"]
+vnc = ["dep:vncserver", "dep:number_prefix", "dep:rusttype"]
 ndi = ["dep:ndi-sdk-sys"]
 
 [lints]

--- a/breakwater/Cargo.toml
+++ b/breakwater/Cargo.toml
@@ -50,8 +50,8 @@ rstest.workspace = true
 [features]
 # We don't enable binary-sync-pixels and binary-set-pixel by default to make it a bit harder for clients ;)
 # VNC and NDI require shared libraries to be installed, so we don't enable them by default
-# Yes, egui and winit require a graphical environment, but many people compile this on a desktop and
-# servers admins generally know what they are doing (tm).
+# Yes, egui and winit require a graphical environment, but most people getting started with
+# breakwater will likely do that on a desktop, servers admins generally know what they are doing (tm).
 default = ["egui", "winit"]
 
 alpha = ["breakwater-parser/alpha"]

--- a/breakwater/Cargo.toml
+++ b/breakwater/Cargo.toml
@@ -23,6 +23,7 @@ color-eyre.workspace = true
 const_format.workspace = true
 eframe = { workspace = true, optional = true }
 egui = { workspace = true, optional = true }
+futures.workspace = true
 libloading = { workspace = true, optional = true }
 local-ip-address.workspace = true
 memadvise.workspace = true
@@ -36,26 +37,28 @@ serde.workspace = true
 simple_moving_average.workspace = true
 softbuffer = { workspace = true, optional = true }
 thiserror.workspace = true
+tokio-stream.workspace = true
 tokio.workspace = true
-tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing.workspace = true
 vncserver = { workspace = true, optional = true }
 winit = { workspace = true, optional = true }
-tokio-stream.workspace = true
-futures.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
 
 [features]
 # We don't enable binary-sync-pixels and binary-set-pixel by default to make it a bit harder for clients ;)
-default = ["egui", "vnc"]
+# VNC and NDI require shared libraries to be installed, so we don't enable them by default
+# Yes, egui and winit require a graphical environment, but many people compile this on a desktop and
+# servers admins generally know what they are doing (tm).
+default = ["egui", "winit"]
 
 alpha = ["breakwater-parser/alpha"]
 binary-set-pixel = ["breakwater-parser/binary-set-pixel"]
 binary-sync-pixels = ["breakwater-parser/binary-sync-pixels"]
 egui = ["dep:breakwater-egui-overlay", "dep:bytemuck", "dep:eframe", "dep:egui", "dep:libloading"]
-native-display = ["dep:softbuffer", "dep:winit"]
+winit = ["dep:softbuffer", "dep:winit"]
 vnc = ["dep:vncserver"]
 ndi = ["dep:ndi-sdk-sys"]
 

--- a/breakwater/src/cli_args.rs
+++ b/breakwater/src/cli_args.rs
@@ -1,12 +1,13 @@
 use std::net::SocketAddr;
 
-use clap::Parser;
 use const_format::formatcp;
+
+use crate::sinks::cli_args::SinkCliArgs;
 
 pub const DEFAULT_NETWORK_BUFFER_SIZE: usize = 256 * 1024;
 pub const DEFAULT_NETWORK_BUFFER_SIZE_STR: &str = formatcp!("{}", DEFAULT_NETWORK_BUFFER_SIZE);
 
-#[derive(Parser, Debug)]
+#[derive(clap::Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 pub struct CliArgs {
     /// Listen address to bind to (multiple can be specified).
@@ -35,11 +36,7 @@ pub struct CliArgs {
     )]
     pub network_buffer_size: i64,
 
-    /// Text to display on the screen.
-    #[clap(short, long, default_value = "Pixelflut server (breakwater)")]
-    pub text: String,
-
-    /// Listen address the prometheus exporter should listen on.
+    /// Listen address the Prometheus exporter should listen on.
     #[clap(short, long, default_value = "[::]:9100")]
     pub prometheus_listen_address: String,
 
@@ -61,12 +58,6 @@ pub struct CliArgs {
     #[clap(short, long)]
     pub connections_per_ip: Option<u64>,
 
-    /// Enable native display output. This requires some form of graphical system (so will probably not work on your
-    /// server).
-    #[cfg(any(feature = "native-display", feature = "egui"))]
-    #[clap(long)]
-    pub native_display: bool,
-
     /// Create (or use an existing) shared memory region for the framebuffer.
     /// This enables other applications to read and write Pixel values to the framebuffer or can be
     /// used to persist the canvas across restarts.
@@ -74,17 +65,5 @@ pub struct CliArgs {
     pub shared_memory_name: Option<String>,
 
     #[clap(flatten)]
-    pub ffmpeg_sink: crate::sinks::ffmpeg::FfmpegSinkCliArgs,
-
-    #[cfg(feature = "egui")]
-    #[clap(flatten)]
-    pub egui_sink: crate::sinks::egui::EguiSinkCliArgs,
-
-    #[cfg(feature = "ndi")]
-    #[clap(flatten)]
-    pub ndi_sink: crate::sinks::ndi::NdiSinkCliArgs,
-
-    #[cfg(feature = "vnc")]
-    #[clap(flatten)]
-    pub vnc_sink: crate::sinks::vnc::VncSinkCliArgs,
+    pub sinks: SinkCliArgs,
 }

--- a/breakwater/src/main.rs
+++ b/breakwater/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use breakwater_parser::SharedMemoryFrameBuffer;
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches};
 use color_eyre::eyre::{self, Context};
 use server::Server;
 use tokio::sync::{broadcast, mpsc};
@@ -39,7 +39,14 @@ async fn main() -> eyre::Result<()> {
         .from_env()?;
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
-    let args = CliArgs::parse();
+    // We parse via `ArgMatches` (instead of `CliArgs::parse()`) so that `SinkCliArgs::validate` can use
+    // `value_source` to tell which sink options were actually passed on the command line.
+    let mut cmd = CliArgs::command();
+    let matches = cmd.get_matches_mut();
+    let args = CliArgs::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
+    if let Err(e) = args.sinks.validate(&mut cmd, &matches) {
+        e.exit();
+    }
 
     // Not using dynamic dispatch here for performance reasons
     let fb = Arc::new(

--- a/breakwater/src/main.rs
+++ b/breakwater/src/main.rs
@@ -9,7 +9,7 @@ use tokio::sync::{broadcast, mpsc};
 use crate::{
     cli_args::CliArgs,
     prometheus_exporter::PrometheusExporter,
-    sinks::{DisplaySink, ffmpeg::FfmpegSink},
+    sinks::start_sinks,
     statistics::{Statistics, StatisticsEvent, StatisticsInformationEvent, StatisticsSaveMode},
 };
 
@@ -52,7 +52,6 @@ async fn main() -> eyre::Result<()> {
     let (statistics_tx, statistics_rx) = mpsc::channel::<StatisticsEvent>(100);
     let (statistics_information_tx, statistics_information_rx) =
         broadcast::channel::<StatisticsInformationEvent>(2);
-    let (terminate_signal_tx, terminate_signal_rx) = broadcast::channel::<()>(1);
 
     let statistics_save_mode = if args.disable_statistics_save_file {
         StatisticsSaveMode::Disabled
@@ -93,114 +92,24 @@ async fn main() -> eyre::Result<()> {
     let statistics_thread = tokio::spawn(async move { statistics.run().await });
     let prometheus_exporter_thread = tokio::spawn(async move { prometheus_exporter.run().await });
 
-    let mut display_sinks = Vec::<Box<dyn DisplaySink<SharedMemoryFrameBuffer> + Send>>::new();
-
-    #[cfg(all(feature = "native-display", not(feature = "egui")))]
-    {
-        use crate::sinks::native_display::NativeDisplaySink;
-
-        if let Some(native_display_sink) =
-            NativeDisplaySink::new(fb.clone(), &args, terminate_signal_rx.resubscribe())
-                .context("failed to create native display sink")?
-        {
-            display_sinks.push(Box::new(native_display_sink));
-        }
-    }
-
-    #[cfg(feature = "vnc")]
-    {
-        use crate::sinks::vnc::VncSink;
-
-        if let Some(vnc_sink) = VncSink::new(
-            fb.clone(),
-            &args.vnc_sink,
-            args.fps,
-            &args.text,
-            statistics_tx.clone(),
-            statistics_information_rx.resubscribe(),
-            terminate_signal_rx.resubscribe(),
-        )
-        .context("failed to create vnc sink")?
-        {
-            display_sinks.push(Box::new(vnc_sink));
-        }
-    }
-
-    #[cfg(feature = "ndi")]
-    {
-        use crate::sinks::ndi::NdiSink;
-
-        if let Some(ndi_sink) = NdiSink::new(
-            fb.clone(),
-            &args.ndi_sink,
-            args.fps,
-            terminate_signal_rx.resubscribe(),
-        )
-        .context("failed to create ndi sink")?
-        {
-            display_sinks.push(Box::new(ndi_sink));
-        }
-    }
-
-    let mut ffmpeg_thread_present = false;
-    if let Some(ffmpeg_sink) = FfmpegSink::new(
+    let (sink_tasks, ffmpeg_thread_present) = start_sinks(
+        &args.sinks,
         fb.clone(),
-        &args.ffmpeg_sink,
+        &args.listen_addresses,
         args.fps,
-        terminate_signal_rx.resubscribe(),
+        statistics_tx,
+        statistics_information_rx,
     )
-    .context("failed to create ffmpeg sink")?
-    {
-        display_sinks.push(Box::new(ffmpeg_sink));
-        ffmpeg_thread_present = true;
-    }
-
-    let mut sink_threads = Vec::new();
-    for mut sink in display_sinks {
-        sink_threads.push(tokio::spawn(async move {
-            sink.run().await?;
-            eyre::Result::<()>::Ok(())
-        }));
-    }
-
-    #[cfg(feature = "egui")]
-    {
-        use sinks::egui::EguiSink;
-
-        match EguiSink::new(
-            fb.clone(),
-            &args.egui_sink,
-            &args.listen_addresses,
-            args.native_display,
-            statistics_information_rx.resubscribe(),
-            terminate_signal_rx.resubscribe(),
-        )
-        .context("failed to create egui sink")?
-        {
-            Some(mut egui_sink) => {
-                tokio::spawn(handle_ctrl_c(terminate_signal_tx));
-
-                // Some platforms require opening windows from the main thread.
-                // The tokio::main macro uses Runtime::block_on(future) which runs the future on
-                // the current thread, which should be the main thread right now.
-                egui_sink.run().await.context("failed to run egui sink")?;
-            }
-            _ => {
-                handle_ctrl_c(terminate_signal_tx).await?;
-            }
-        }
-    }
-
-    #[cfg(not(feature = "egui"))]
-    handle_ctrl_c(terminate_signal_tx).await?;
+    .await
+    .context("failed to start sinks")?;
 
     prometheus_exporter_thread.abort();
     server_listener_thread.abort();
 
-    for sink_thread in sink_threads {
-        sink_thread
+    for sink_task in sink_tasks {
+        sink_task
             .await
-            .context("failed to join sink thread")?
+            .context("failed to join sink task")?
             .context("failed to stop sink")?;
     }
 
@@ -214,18 +123,6 @@ async fn main() -> eyre::Result<()> {
     } else {
         tracing::info!("successfully shut down");
     }
-
-    Ok(())
-}
-
-async fn handle_ctrl_c(terminate_signal_tx: broadcast::Sender<()>) -> eyre::Result<()> {
-    tokio::signal::ctrl_c()
-        .await
-        .context("failed to wait for ctrl + c")?;
-
-    terminate_signal_tx
-        .send(())
-        .context("failed to signal termination")?;
 
     Ok(())
 }

--- a/breakwater/src/sinks/cli_args.rs
+++ b/breakwater/src/sinks/cli_args.rs
@@ -92,6 +92,14 @@ impl SinkCliArgs {
                 .map_err(|msg| cmd.error(ErrorKind::MissingRequiredArgument, msg))?;
         }
 
+        #[cfg(all(feature = "egui", feature = "winit"))]
+        if self.enabled_sinks.contains(&Sink::Egui) && self.enabled_sinks.contains(&Sink::Winit) {
+            return Err(cmd.error(
+                ErrorKind::ArgumentConflict,
+                "the egui and winit sinks can not be enabled at the same time",
+            ));
+        }
+
         Ok(())
     }
 }

--- a/breakwater/src/sinks/cli_args.rs
+++ b/breakwater/src/sinks/cli_args.rs
@@ -1,3 +1,5 @@
+use clap::{ValueEnum, error::ErrorKind, parser::ValueSource};
+
 use crate::sinks::Sink;
 
 #[derive(clap::Args, Debug)]
@@ -21,4 +23,63 @@ pub struct SinkCliArgs {
     #[cfg(feature = "vnc")]
     #[clap(flatten)]
     pub vnc_sink: crate::sinks::vnc::VncSinkCliArgs,
+}
+
+impl SinkCliArgs {
+    /// Reject sink-specific options (e.g. `--vnc-text`) that were passed on the command line without the
+    /// corresponding sink being enabled via `--enable-sink`.
+    ///
+    /// clap can not express this natively: its relational checks (`requires`, `conflicts_with`, ...) operate on
+    /// argument presence, not on a specific value being contained in a multi-valued enum argument like
+    /// `enabled_sinks`. So we detect explicitly-passed options via [`ArgMatches::value_source`] and validate manually.
+    pub fn validate(
+        &self,
+        cmd: &mut clap::Command,
+        matches: &clap::ArgMatches,
+    ) -> Result<(), clap::Error> {
+        // (clap arg id [= field name], user-facing flag, sink the option belongs to)
+        #[allow(unused_mut)]
+        let mut checks: Vec<(&str, &str, Sink)> = vec![
+            ("rtmp_address", "--ffmpeg-rtmp-address", Sink::Ffmpeg),
+            ("video_save_folder", "--ffmpeg-video-save-folder", Sink::Ffmpeg),
+        ];
+        #[cfg(feature = "egui")]
+        checks.extend([
+            ("viewports", "--egui-viewport", Sink::Egui),
+            (
+                "advertised_endpoints",
+                "--egui-advertised-endpoint",
+                Sink::Egui,
+            ),
+            ("ui", "--egui-ui", Sink::Egui),
+        ]);
+        #[cfg(feature = "ndi")]
+        checks.push(("source_name", "--ndi-source-name", Sink::Ndi));
+        #[cfg(feature = "vnc")]
+        checks.extend([
+            ("vnc_listen_addresses", "--vnc-listen-address", Sink::Vnc),
+            ("text", "--vnc-text", Sink::Vnc),
+            ("font", "--vnc-font", Sink::Vnc),
+        ]);
+
+        for (arg_id, flag, sink) in checks {
+            let passed = matches.value_source(arg_id) == Some(ValueSource::CommandLine);
+            if passed && !self.enabled_sinks.contains(&sink) {
+                let sink_name = sink
+                    .to_possible_value()
+                    .expect("every Sink variant has a name")
+                    .get_name()
+                    .to_owned();
+                return Err(cmd.error(
+                    ErrorKind::ArgumentConflict,
+                    format!(
+                        "the argument '{flag}' can only be used when the '{sink_name}' sink is enabled \
+                         (pass '--enable-sink {sink_name}')"
+                    ),
+                ));
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/breakwater/src/sinks/cli_args.rs
+++ b/breakwater/src/sinks/cli_args.rs
@@ -37,47 +37,45 @@ impl SinkCliArgs {
         cmd: &mut clap::Command,
         matches: &clap::ArgMatches,
     ) -> Result<(), clap::Error> {
-        // (clap arg id [= field name], user-facing flag, sink the option belongs to)
-        #[allow(unused_mut)]
-        let mut checks: Vec<(&str, &str, Sink)> = vec![
-            ("rtmp_address", "--ffmpeg-rtmp-address", Sink::Ffmpeg),
-            ("video_save_folder", "--ffmpeg-video-save-folder", Sink::Ffmpeg),
-        ];
-        #[cfg(feature = "egui")]
-        checks.extend([
-            ("viewports", "--egui-viewport", Sink::Egui),
-            (
-                "advertised_endpoints",
-                "--egui-advertised-endpoint",
-                Sink::Egui,
-            ),
-            ("ui", "--egui-ui", Sink::Egui),
-        ]);
-        #[cfg(feature = "ndi")]
-        checks.push(("source_name", "--ndi-source-name", Sink::Ndi));
-        #[cfg(feature = "vnc")]
-        checks.extend([
-            ("vnc_listen_addresses", "--vnc-listen-address", Sink::Vnc),
-            ("text", "--vnc-text", Sink::Vnc),
-            ("font", "--vnc-font", Sink::Vnc),
-        ]);
-
-        for (arg_id, flag, sink) in checks {
-            let passed = matches.value_source(arg_id) == Some(ValueSource::CommandLine);
-            if passed && !self.enabled_sinks.contains(&sink) {
-                let sink_name = sink
+        // Every sink-specific option is named with its sink as prefix (e.g. `--vnc-text` belongs to the
+        // `vnc` sink). We rely on that convention to detect options that were passed without their sink
+        // being enabled, instead of hardcoding the full list of arguments here.
+        let sink_prefixes: Vec<(String, String, Sink)> = Sink::value_variants()
+            .iter()
+            .map(|sink| {
+                let name = sink
                     .to_possible_value()
                     .expect("every Sink variant has a name")
                     .get_name()
                     .to_owned();
-                return Err(cmd.error(
-                    ErrorKind::ArgumentConflict,
-                    format!(
-                        "the argument '{flag}' can only be used when the '{sink_name}' sink is enabled \
-                         (pass '--enable-sink {sink_name}')"
-                    ),
-                ));
+                (format!("{name}-"), name, *sink)
+            })
+            .collect();
+
+        // We can't call `cmd.error` (needs `&mut cmd`) while iterating `cmd.get_arguments()` (borrows `cmd`),
+        // so we first collect the offending (flag, sink name) and build the error afterwards.
+        let mut conflict = None;
+        'args: for arg in cmd.get_arguments() {
+            let Some(long) = arg.get_long() else { continue };
+            if matches.value_source(arg.get_id().as_str()) != Some(ValueSource::CommandLine) {
+                continue;
             }
+            for (prefix, name, sink) in &sink_prefixes {
+                if long.starts_with(prefix) && !self.enabled_sinks.contains(sink) {
+                    conflict = Some((format!("--{long}"), name.clone()));
+                    break 'args;
+                }
+            }
+        }
+
+        if let Some((flag, sink_name)) = conflict {
+            return Err(cmd.error(
+                ErrorKind::ArgumentConflict,
+                format!(
+                    "the argument '{flag}' can only be used when the '{sink_name}' sink is enabled \
+                     (pass '--enable-sink {sink_name}')"
+                ),
+            ));
         }
 
         // Validate that every enabled sink got the arguments it requires. Each sink encapsulates its own

--- a/breakwater/src/sinks/cli_args.rs
+++ b/breakwater/src/sinks/cli_args.rs
@@ -31,7 +31,7 @@ impl SinkCliArgs {
     ///
     /// clap can not express this natively: its relational checks (`requires`, `conflicts_with`, ...) operate on
     /// argument presence, not on a specific value being contained in a multi-valued enum argument like
-    /// `enabled_sinks`. So we detect explicitly-passed options via [`ArgMatches::value_source`] and validate manually.
+    /// `enabled_sinks`. So we detect explicitly-passed options via [`clap::ArgMatches::value_source`] and validate manually.
     pub fn validate(
         &self,
         cmd: &mut clap::Command,

--- a/breakwater/src/sinks/cli_args.rs
+++ b/breakwater/src/sinks/cli_args.rs
@@ -80,6 +80,20 @@ impl SinkCliArgs {
             }
         }
 
+        // Validate that every enabled sink got the arguments it requires. Each sink encapsulates its own
+        // requirements in a `validate` method, which we only invoke when that sink is actually enabled.
+        if self.enabled_sinks.contains(&Sink::Ffmpeg) {
+            self.ffmpeg_sink
+                .validate()
+                .map_err(|msg| cmd.error(ErrorKind::MissingRequiredArgument, msg))?;
+        }
+        #[cfg(feature = "vnc")]
+        if self.enabled_sinks.contains(&Sink::Vnc) {
+            self.vnc_sink
+                .validate()
+                .map_err(|msg| cmd.error(ErrorKind::MissingRequiredArgument, msg))?;
+        }
+
         Ok(())
     }
 }

--- a/breakwater/src/sinks/cli_args.rs
+++ b/breakwater/src/sinks/cli_args.rs
@@ -1,0 +1,24 @@
+use crate::sinks::Sink;
+
+#[derive(clap::Args, Debug)]
+pub struct SinkCliArgs {
+    /// Enable an arbitrary number of sinks (argument can be repeated). The availability of sinks depends on the enabled features.
+    #[clap(short = 's', long = "enable-sink")]
+    pub enabled_sinks: Vec<Sink>,
+
+    #[clap(flatten)]
+    pub ffmpeg_sink: crate::sinks::ffmpeg::FfmpegSinkCliArgs,
+
+    #[cfg(feature = "egui")]
+    #[clap(flatten)]
+    pub egui_sink: crate::sinks::egui::EguiSinkCliArgs,
+
+    // winit doesn't have any CLI arguments
+    #[cfg(feature = "ndi")]
+    #[clap(flatten)]
+    pub ndi_sink: crate::sinks::ndi::NdiSinkCliArgs,
+
+    #[cfg(feature = "vnc")]
+    #[clap(flatten)]
+    pub vnc_sink: crate::sinks::vnc::VncSinkCliArgs,
+}

--- a/breakwater/src/sinks/egui/mod.rs
+++ b/breakwater/src/sinks/egui/mod.rs
@@ -20,12 +20,10 @@ mod view;
 
 #[derive(Clone, Debug, clap::Args)]
 #[command(next_help_heading = "egui sink options")]
-#[allow(clippy::struct_field_names)]
 pub struct EguiSinkCliArgs {
     /// Specify a view port to display the canvas or a certain part of it. Format: `<offset_x>x<offset_y>,<width>x<height>`.
     /// Might be specified multiple times for more than one viewport. Useful for multi-projector setups.
     /// Defaults to display the entire canvas.
-    /// Implies --native-display.
     #[clap(long = "egui-viewport")]
     pub viewports: Vec<crate::sinks::egui::ViewportConfig>,
 
@@ -34,7 +32,6 @@ pub struct EguiSinkCliArgs {
     pub advertised_endpoints: Vec<String>,
 
     /// Provide a path to a dylib containing a custom egui overlay.
-    /// Implies --native-display.
     //
     // Qualifying import here to avoid feature-specific imports
     #[clap(long = "egui-ui")]

--- a/breakwater/src/sinks/egui/mod.rs
+++ b/breakwater/src/sinks/egui/mod.rs
@@ -9,31 +9,35 @@ use tokio::sync::broadcast;
 use tracing::instrument;
 
 use super::DisplaySink;
-use crate::statistics::StatisticsInformationEvent;
+use crate::{
+    sinks::{DisplaySinkType, Sink},
+    statistics::StatisticsInformationEvent,
+};
 
 mod canvas_renderer;
 mod dynamic_overlay;
 mod view;
 
-#[derive(Clone, Debug, clap::Parser)]
+#[derive(Clone, Debug, clap::Args)]
 #[command(next_help_heading = "egui sink options")]
+#[allow(clippy::struct_field_names)]
 pub struct EguiSinkCliArgs {
     /// Specify a view port to display the canvas or a certain part of it. Format: `<offset_x>x<offset_y>,<width>x<height>`.
     /// Might be specified multiple times for more than one viewport. Useful for multi-projector setups.
     /// Defaults to display the entire canvas.
     /// Implies --native-display.
-    #[clap(long)]
-    pub viewport: Vec<crate::sinks::egui::ViewportConfig>,
+    #[clap(long = "egui-viewport")]
+    pub viewports: Vec<crate::sinks::egui::ViewportConfig>,
 
     /// Specify one or more pixelflut endpoints to display.
-    #[clap(long)]
+    #[clap(long = "egui-advertised-endpoint")]
     pub advertised_endpoints: Vec<String>,
 
     /// Provide a path to a dylib containing a custom egui overlay.
     /// Implies --native-display.
     //
     // Qualifying import here to avoid feature-specific imports
-    #[clap(long)]
+    #[clap(long = "egui-ui")]
     pub ui: Option<std::path::PathBuf>,
 }
 
@@ -95,24 +99,23 @@ impl<FB: FrameBuffer + Send + Sync + 'static> EguiSink<FB> {
     pub fn new(
         fb: Arc<FB>,
         EguiSinkCliArgs {
-            viewport,
+            viewports,
             advertised_endpoints,
             ui,
         }: &EguiSinkCliArgs,
         listen_addresses: &[SocketAddr],
-        native_display: bool,
         statistics_information_rx: broadcast::Receiver<StatisticsInformationEvent>,
         terminate_signal_rx: broadcast::Receiver<()>,
-    ) -> eyre::Result<Option<Self>> {
-        let viewports = match (viewport.as_slice(), native_display, ui.as_ref()) {
-            (vp, _, _) if !vp.is_empty() => Vec::from(vp),
-            ([], _, Some(_)) | ([], true, _) => vec![ViewportConfig {
+    ) -> eyre::Result<Self> {
+        let viewports = if viewports.is_empty() {
+            vec![ViewportConfig {
                 x: 0,
                 y: 0,
                 width: fb.get_width(),
                 height: fb.get_height(),
-            }],
-            _ => return Ok(None),
+            }]
+        } else {
+            viewports.clone()
         };
 
         let ui_overlay = Arc::new({
@@ -149,14 +152,20 @@ impl<FB: FrameBuffer + Send + Sync + 'static> EguiSink<FB> {
             advertised_endpoints.clone()
         };
 
-        Ok(Some(Self {
+        Ok(Self {
             framebuffer: fb,
             viewports,
             terminate_rx: terminate_signal_rx,
             stats_rx: statistics_information_rx,
             advertised_endpoints,
             ui_overlay,
-        }))
+        })
+    }
+}
+
+impl<FB: FrameBuffer + Send + Sync + 'static> DisplaySinkType<FB> for EguiSink<FB> {
+    fn sink_type() -> Sink {
+        Sink::Egui
     }
 }
 

--- a/breakwater/src/sinks/ffmpeg.rs
+++ b/breakwater/src/sinks/ffmpeg.rs
@@ -21,6 +21,20 @@ pub struct FfmpegSinkCliArgs {
     pub video_save_folder: Option<String>,
 }
 
+impl FfmpegSinkCliArgs {
+    /// Validates the arguments under the assumption that the ffmpeg sink is enabled.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.rtmp_address.is_none() && self.video_save_folder.is_none() {
+            return Err(
+                "the ffmpeg sink requires either '--ffmpeg-rtmp-address' or '--ffmpeg-video-save-folder' to be specified"
+                    .to_owned(),
+            );
+        }
+
+        Ok(())
+    }
+}
+
 pub struct FfmpegSink<FB: FrameBuffer> {
     cli_args: FfmpegSinkCliArgs,
     fb: Arc<FB>,

--- a/breakwater/src/sinks/ffmpeg.rs
+++ b/breakwater/src/sinks/ffmpeg.rs
@@ -3,21 +3,21 @@ use std::{process::Stdio, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use breakwater_parser::FrameBuffer;
 use chrono::Local;
-use color_eyre::eyre::{self, Context};
+use color_eyre::eyre::{self, Context, bail};
 use tokio::{io::AsyncWriteExt, process::Command, sync::broadcast, time};
 use tracing::instrument;
 
-use crate::sinks::DisplaySink;
+use crate::sinks::{DisplaySink, DisplaySinkType, Sink};
 
-#[derive(Clone, Debug, clap::Parser)]
+#[derive(Clone, Debug, clap::Args)]
 #[command(next_help_heading = "ffmpeg sink options")]
 pub struct FfmpegSinkCliArgs {
     /// Enable rtmp streaming to configured address, e.g. `rtmp://127.0.0.1:1935/live/test`
-    #[clap(long)]
+    #[clap(long = "ffmpeg-rtmp-address")]
     pub rtmp_address: Option<String>,
 
     /// Enable dump of video stream into file. File location will be `<VIDEO_SAVE_FOLDER>/pixelflut_dump_{timestamp}.mp4`
-    #[clap(long)]
+    #[clap(long = "ffmpeg-video-save-folder")]
     pub video_save_folder: Option<String>,
 }
 
@@ -29,23 +29,25 @@ pub struct FfmpegSink<FB: FrameBuffer> {
 }
 
 impl<FB: FrameBuffer + Sync + Send> FfmpegSink<FB> {
-    #[instrument(skip_all, err)]
+    #[instrument(skip_all)]
     pub fn new(
         fb: Arc<FB>,
         cli_args: &FfmpegSinkCliArgs,
         fps: u32,
         terminate_signal_rx: broadcast::Receiver<()>,
-    ) -> eyre::Result<Option<Self>> {
-        if cli_args.rtmp_address.is_some() || cli_args.video_save_folder.is_some() {
-            Ok(Some(Self {
-                cli_args: cli_args.to_owned(),
-                fb,
-                fps,
-                terminate_signal_rx,
-            }))
-        } else {
-            Ok(None)
+    ) -> Self {
+        Self {
+            cli_args: cli_args.clone(),
+            fb,
+            fps,
+            terminate_signal_rx,
         }
+    }
+}
+
+impl<FB: FrameBuffer + Sync + Send> DisplaySinkType<FB> for FfmpegSink<FB> {
+    fn sink_type() -> Sink {
+        Sink::Ffmpeg
     }
 }
 
@@ -102,8 +104,8 @@ impl<FB: FrameBuffer + Sync + Send> DisplaySink<FB> for FfmpegSink<FB> {
                 Some(video_save_folder) => {
                     ffmpeg_args.extend([Self::video_file(video_save_folder)]);
                 }
-                None => unreachable!(
-                    "FfmpegSink can only be created when either rtmp or video file is activated"
+                None => bail!(
+                    "ffmpeg sink can only be used when either RTMP or video file is activated"
                 ),
             },
         }

--- a/breakwater/src/sinks/mod.rs
+++ b/breakwater/src/sinks/mod.rs
@@ -1,19 +1,175 @@
-use async_trait::async_trait;
-use color_eyre::eyre;
+use std::{net::SocketAddr, sync::Arc};
 
+use async_trait::async_trait;
+use breakwater_parser::FrameBuffer;
+use color_eyre::eyre::{self, Context};
+use tokio::{
+    sync::{broadcast, mpsc},
+    task::JoinHandle,
+};
+use tracing::warn;
+
+use crate::{
+    sinks::{cli_args::SinkCliArgs, ffmpeg::FfmpegSink},
+    statistics::{StatisticsEvent, StatisticsInformationEvent},
+};
+
+pub mod cli_args;
 #[cfg(feature = "egui")]
 pub mod egui;
 pub mod ffmpeg;
-#[cfg(all(feature = "native-display", not(feature = "egui")))]
-pub mod native_display;
 #[cfg(feature = "ndi")]
 pub mod ndi;
 #[cfg(feature = "vnc")]
 pub mod vnc;
+#[cfg(feature = "winit")]
+pub mod winit;
 
 // The stabilization of async functions in traits in Rust 1.75 did not include support for using traits containing async
 // functions as dyn Trait, so we still need to use async_trait here.
 #[async_trait]
 pub trait DisplaySink<FB> {
     async fn run(&mut self) -> eyre::Result<()>;
+}
+
+/// We can not add the `sink_type` function to [`DisplaySink`], as it needs to stay dyn compatible.
+pub trait DisplaySinkType<FB>: DisplaySink<FB> {
+    fn sink_type() -> Sink;
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum Sink {
+    Ffmpeg,
+    #[cfg(feature = "egui")]
+    Egui,
+    #[cfg(feature = "winit")]
+    Winit,
+    #[cfg(feature = "vnc")]
+    Vnc,
+    #[cfg(feature = "ndi")]
+    Ndi,
+}
+
+pub async fn start_sinks<FB: FrameBuffer + Send + Sync + 'static>(
+    cli_args: &SinkCliArgs,
+    fb: Arc<FB>,
+    listen_addresses: &[SocketAddr],
+    fps: u32,
+    statistics_tx: mpsc::Sender<StatisticsEvent>,
+    statistics_information_rx: broadcast::Receiver<StatisticsInformationEvent>,
+) -> eyre::Result<(Vec<JoinHandle<eyre::Result<()>>>, bool)> {
+    let enabled_sinks = &cli_args.enabled_sinks;
+    if enabled_sinks.is_empty() {
+        warn!("No sinks enabled, not displaying/serving anything");
+    }
+
+    let (terminate_signal_tx, terminate_signal_rx) = broadcast::channel::<()>(1);
+
+    let mut sinks = Vec::<Box<dyn DisplaySink<FB> + Send>>::new();
+
+    let mut ffmpeg_thread_present = false;
+    if enabled_sinks.contains(&FfmpegSink::<FB>::sink_type()) {
+        sinks.push(Box::new(FfmpegSink::new(
+            fb.clone(),
+            &cli_args.ffmpeg_sink,
+            fps,
+            terminate_signal_rx.resubscribe(),
+        )));
+        ffmpeg_thread_present = true;
+    }
+
+    #[cfg(feature = "winit")]
+    {
+        use crate::sinks::winit::WinitSink;
+        if enabled_sinks.contains(&WinitSink::<FB>::sink_type()) {
+            sinks.push(Box::new(WinitSink::new(
+                fb.clone(),
+                terminate_signal_rx.resubscribe(),
+            )));
+        }
+    }
+
+    #[cfg(feature = "vnc")]
+    {
+        use crate::sinks::vnc::VncSink;
+        if enabled_sinks.contains(&VncSink::<FB>::sink_type()) {
+            sinks.push(Box::new(
+                VncSink::new(
+                    fb.clone(),
+                    &cli_args.vnc_sink,
+                    fps,
+                    statistics_tx,
+                    statistics_information_rx.resubscribe(),
+                    terminate_signal_rx.resubscribe(),
+                )
+                .context("failed to create VNC sink")?,
+            ));
+        }
+    }
+
+    #[cfg(feature = "ndi")]
+    {
+        use crate::sinks::ndi::NdiSink;
+        if enabled_sinks.contains(&NdiSink::<FB>::sink_type()) {
+            sinks.push(Box::new(
+                NdiSink::new(
+                    fb.clone(),
+                    &cli_args.ndi_sink,
+                    fps,
+                    terminate_signal_rx.resubscribe(),
+                )
+                .context("failed to create NDI sink")?,
+            ));
+        }
+    }
+
+    let mut sink_tasks = Vec::new();
+    for mut sink in sinks {
+        sink_tasks.push(tokio::spawn(async move {
+            sink.run().await?;
+            eyre::Ok(())
+        }));
+    }
+
+    // Egui needs some special handling around threads, so it differs a bit
+    #[cfg(feature = "egui")]
+    {
+        use crate::sinks::egui::EguiSink;
+        if enabled_sinks.contains(&EguiSink::<FB>::sink_type()) {
+            let mut egui_sink = EguiSink::new(
+                fb.clone(),
+                &cli_args.egui_sink,
+                listen_addresses,
+                statistics_information_rx.resubscribe(),
+                terminate_signal_rx.resubscribe(),
+            )
+            .context("failed to create egui sink")?;
+
+            tokio::spawn(handle_ctrl_c(terminate_signal_tx));
+
+            // Some platforms require opening windows from the main thread.
+            // The tokio::main macro uses Runtime::block_on(future) which runs the future on
+            // the current thread, which should be the main thread right now.
+            egui_sink.run().await.context("failed to run egui sink")?;
+        } else {
+            handle_ctrl_c(terminate_signal_tx).await?;
+        }
+    }
+
+    #[cfg(not(feature = "egui"))]
+    handle_ctrl_c(terminate_signal_tx).await?;
+
+    Ok((sink_tasks, ffmpeg_thread_present))
+}
+
+async fn handle_ctrl_c(terminate_signal_tx: broadcast::Sender<()>) -> eyre::Result<()> {
+    tokio::signal::ctrl_c()
+        .await
+        .context("failed to wait for ctrl + c")?;
+
+    terminate_signal_tx
+        .send(())
+        .context("failed to signal termination")?;
+
+    Ok(())
 }

--- a/breakwater/src/sinks/mod.rs
+++ b/breakwater/src/sinks/mod.rs
@@ -50,6 +50,9 @@ pub enum Sink {
     Ndi,
 }
 
+// Several of these parameters are only consumed by feature-gated sinks, so they appear unused when those
+// features are disabled. We can't use `#[expect(...)]` here, as it would fail when all features are enabled.
+#[allow(unused_variables)]
 pub async fn start_sinks<FB: FrameBuffer + Send + Sync + 'static>(
     cli_args: &SinkCliArgs,
     fb: Arc<FB>,

--- a/breakwater/src/sinks/ndi.rs
+++ b/breakwater/src/sinks/ndi.rs
@@ -15,18 +15,17 @@ use ndi_sdk_sys::{
 use tokio::sync::broadcast;
 use tracing::{error, info, instrument, trace};
 
-use crate::sinks::DisplaySink;
+use crate::sinks::{DisplaySink, DisplaySinkType, Sink};
 
-#[derive(Clone, Debug, clap::Parser)]
+#[derive(Clone, Debug, clap::Args)]
 #[command(next_help_heading = "NDI sink options")]
 pub struct NdiSinkCliArgs {
-    /// Enable the NDI source
-    #[clap(long)]
-    pub ndi: bool,
-
-    /// Readable NDI source name. Requires --ndi to be set.
-    #[clap(long, default_value = "breakwater canvas", requires = "ndi")]
-    pub ndi_source_name: String,
+    /// Readable NDI source name
+    #[clap(
+        long = "ndi-source-name",
+        default_value = "Pixelflut server (breakwater="
+    )]
+    pub source_name: String,
 }
 
 pub struct NdiSink<FB: FrameBuffer> {
@@ -41,17 +40,10 @@ impl<FB: FrameBuffer + Sync + Send + 'static> NdiSink<FB> {
     #[instrument(skip_all, err)]
     pub fn new(
         fb: Arc<FB>,
-        NdiSinkCliArgs {
-            ndi,
-            ndi_source_name,
-        }: &NdiSinkCliArgs,
+        NdiSinkCliArgs { source_name }: &NdiSinkCliArgs,
         fps: u32,
         terminate_signal_rx: broadcast::Receiver<()>,
-    ) -> eyre::Result<Option<Self>> {
-        if !ndi {
-            return Ok(None);
-        }
-
+    ) -> eyre::Result<Self> {
         info!(
             version = sdk::version().unwrap_or("NDI SDK version unavailable"),
             "NDI SDK version",
@@ -59,7 +51,7 @@ impl<FB: FrameBuffer + Sync + Send + 'static> NdiSink<FB> {
         sdk::initialize().context("failed to initialize NDI SDK")?;
 
         let source = NDISenderBuilder::new()
-            .name(ndi_source_name)?
+            .name(source_name)?
             .clock_video(true)
             .build()
             .context("failed to build NDI sender")?;
@@ -73,12 +65,18 @@ impl<FB: FrameBuffer + Sync + Send + 'static> NdiSink<FB> {
             "Started NDI source",
         );
 
-        Ok(Some(Self {
+        Ok(Self {
             fb,
             terminate_signal_rx,
             source: Arc::new(source),
             fps,
-        }))
+        })
+    }
+}
+
+impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySinkType<FB> for NdiSink<FB> {
+    fn sink_type() -> Sink {
+        Sink::Ndi
     }
 }
 

--- a/breakwater/src/sinks/ndi.rs
+++ b/breakwater/src/sinks/ndi.rs
@@ -23,7 +23,7 @@ pub struct NdiSinkCliArgs {
     /// Readable NDI source name
     #[clap(
         long = "ndi-source-name",
-        default_value = "Pixelflut server (breakwater="
+        default_value = "Pixelflut server (breakwater)"
     )]
     pub source_name: String,
 }

--- a/breakwater/src/sinks/vnc.rs
+++ b/breakwater/src/sinks/vnc.rs
@@ -22,7 +22,7 @@ use vncserver::{
 };
 
 use crate::{
-    sinks::DisplaySink,
+    sinks::{DisplaySink, DisplaySinkType, Sink},
     statistics::{
         STATISTICS_INFO_RECV_ERR, STATISTICS_SEND_ERR, StatisticsEvent, StatisticsInformationEvent,
     },
@@ -30,18 +30,26 @@ use crate::{
 
 const STATS_HEIGHT: usize = 35;
 
-#[derive(Clone, Debug, clap::Parser)]
+#[derive(Clone, Debug, clap::Args)]
 #[command(next_help_heading = "VNC sink options")]
+#[allow(clippy::struct_field_names)]
 pub struct VncSinkCliArgs {
     /// VNC server listen address to bind to (multiple can be specified).
     /// Only one address of each IP version can be specified
+    //
+    // We can't call it listen_addresses because of
+    // Command breakwater: Argument names must be unique, but 'listen_addresses' is in use by more than one argument or group
     #[clap(long = "vnc-listen-address")]
     pub vnc_listen_addresses: Vec<SocketAddr>,
+
+    /// Text to display on the screen.
+    #[clap(long = "vnc-text", default_value = "Pixelflut server (breakwater)")]
+    pub text: String,
 
     /// The font used to render the text on the screen.
     /// Should be a ttf file.
     /// If you use the default value a copy that ships with breakwater will be used - no need to download and provide the font.
-    #[clap(long, default_value = "Arial.ttf")]
+    #[clap(long = "vnc-font", default_value = "Arial.ttf")]
     pub font: String,
 }
 
@@ -64,20 +72,15 @@ impl<FB: FrameBuffer + Sync + Send> VncSink<'_, FB> {
     pub fn new(
         fb: Arc<FB>,
         VncSinkCliArgs {
-            vnc_listen_addresses,
+            vnc_listen_addresses: listen_addresses,
+            text,
             font,
         }: &VncSinkCliArgs,
         fps: u32,
-        text: &str,
         statistics_tx: mpsc::Sender<StatisticsEvent>,
         statistics_information_rx: broadcast::Receiver<StatisticsInformationEvent>,
         terminate_signal_rx: broadcast::Receiver<()>,
-    ) -> eyre::Result<Option<Self>> {
-        if vnc_listen_addresses.is_empty() {
-            tracing::debug!("VNC sink not enabled as no vnc addresses are specified");
-            return Ok(None);
-        }
-
+    ) -> eyre::Result<Self> {
         // We ship our own copy of Arial.ttf, so that users don't need to download and provide it
         let font = if font.as_str() == "Arial.ttf" {
             let font_bytes = include_bytes!("../../../Arial.ttf");
@@ -101,7 +104,7 @@ impl<FB: FrameBuffer + Sync + Send> VncSink<'_, FB> {
             (*screen).ipv6port = -1;
         }
 
-        let (v4, v6) = vnc_listen_addresses_v4_v6(vnc_listen_addresses)?;
+        let (v4, v6) = vnc_listen_addresses_v4_v6(listen_addresses)?;
 
         if let Some(v4) = v4 {
             unsafe {
@@ -129,8 +132,7 @@ impl<FB: FrameBuffer + Sync + Send> VncSink<'_, FB> {
             }
         }
 
-        // FIXME: Only return Some in case VNC is enabled
-        Ok(Some(Self {
+        Ok(Self {
             fb,
             statistics_tx,
             statistics_information_rx,
@@ -139,7 +141,13 @@ impl<FB: FrameBuffer + Sync + Send> VncSink<'_, FB> {
             fps,
             text: text.to_owned(),
             font,
-        }))
+        })
+    }
+}
+
+impl<FB: FrameBuffer + Sync + Send> DisplaySinkType<FB> for VncSink<'_, FB> {
+    fn sink_type() -> Sink {
+        Sink::Vnc
     }
 }
 

--- a/breakwater/src/sinks/vnc.rs
+++ b/breakwater/src/sinks/vnc.rs
@@ -52,6 +52,19 @@ pub struct VncSinkCliArgs {
     pub font: String,
 }
 
+impl VncSinkCliArgs {
+    /// Validates the arguments under the assumption that the VNC sink is enabled.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.vnc_listen_addresses.is_empty() {
+            return Err(
+                "the VNC sink requires at least one '--vnc-listen-address' to be specified".to_owned(),
+            );
+        }
+
+        Ok(())
+    }
+}
+
 // Sorry! Help needed :)
 unsafe impl<FB: FrameBuffer> Send for VncSink<'_, FB> {}
 

--- a/breakwater/src/sinks/vnc.rs
+++ b/breakwater/src/sinks/vnc.rs
@@ -32,7 +32,6 @@ const STATS_HEIGHT: usize = 35;
 
 #[derive(Clone, Debug, clap::Args)]
 #[command(next_help_heading = "VNC sink options")]
-#[allow(clippy::struct_field_names)]
 pub struct VncSinkCliArgs {
     /// VNC server listen address to bind to (multiple can be specified).
     /// Only one address of each IP version can be specified

--- a/breakwater/src/sinks/vnc.rs
+++ b/breakwater/src/sinks/vnc.rs
@@ -57,7 +57,8 @@ impl VncSinkCliArgs {
     pub fn validate(&self) -> Result<(), String> {
         if self.vnc_listen_addresses.is_empty() {
             return Err(
-                "the VNC sink requires at least one '--vnc-listen-address' to be specified".to_owned(),
+                "the VNC sink requires at least one '--vnc-listen-address' to be specified"
+                    .to_owned(),
             );
         }
 

--- a/breakwater/src/sinks/winit.rs
+++ b/breakwater/src/sinks/winit.rs
@@ -19,39 +19,37 @@ use winit::platform::wayland::EventLoopBuilderExtWayland;
 #[cfg(target_family = "windows")]
 use winit::platform::windows::EventLoopBuilderExtWindows;
 
-use crate::{cli_args::CliArgs, sinks::DisplaySink};
+use crate::sinks::{DisplaySink, DisplaySinkType, Sink};
 
 // Sorry! Help needed :)
-unsafe impl<FB: FrameBuffer> Send for NativeDisplaySink<FB> {}
+unsafe impl<FB: FrameBuffer> Send for WinitSink<FB> {}
 
-pub struct NativeDisplaySink<FB: FrameBuffer> {
+pub struct WinitSink<FB: FrameBuffer> {
     fb: Arc<FB>,
     terminate_signal_rx: broadcast::Receiver<()>,
 
     surface: Option<softbuffer::Surface<DisplayHandle<'static>, Arc<Window>>>,
 }
 
-impl<FB: FrameBuffer + Sync + Send + 'static> NativeDisplaySink<FB> {
-    #[instrument(skip_all, err)]
-    pub fn new(
-        fb: Arc<FB>,
-        cli_args: &CliArgs,
-        terminate_signal_rx: broadcast::Receiver<()>,
-    ) -> eyre::Result<Option<Self>> {
-        if !cli_args.native_display {
-            return Ok(None);
-        }
-
-        Ok(Some(Self {
+impl<FB: FrameBuffer + Sync + Send + 'static> WinitSink<FB> {
+    #[instrument(skip_all)]
+    pub fn new(fb: Arc<FB>, terminate_signal_rx: broadcast::Receiver<()>) -> Self {
+        Self {
             fb,
             terminate_signal_rx,
             surface: None,
-        }))
+        }
+    }
+}
+
+impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySinkType<FB> for WinitSink<FB> {
+    fn sink_type() -> Sink {
+        Sink::Winit
     }
 }
 
 #[async_trait]
-impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NativeDisplaySink<FB> {
+impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for WinitSink<FB> {
     #[instrument(skip(self), err)]
     async fn run(&mut self) -> eyre::Result<()> {
         let fb_clone = self.fb.clone();
@@ -82,13 +80,13 @@ impl<FB: FrameBuffer + Sync + Send + 'static> DisplaySink<FB> for NativeDisplayS
             eyre::Result::<()>::Ok(())
         })
         .await
-        .context("failed to join native display thread")??;
+        .context("failed to join winit display thread")??;
 
         Ok(())
     }
 }
 
-impl<FB: FrameBuffer> ApplicationHandler for NativeDisplaySink<FB> {
+impl<FB: FrameBuffer> ApplicationHandler for WinitSink<FB> {
     fn resumed(&mut self, event_loop: &winit::event_loop::ActiveEventLoop) {
         let window = Arc::new(
             event_loop
@@ -171,11 +169,11 @@ impl<FB: FrameBuffer> ApplicationHandler for NativeDisplaySink<FB> {
             _ => {
                 tracing::debug!(?event, "received window event");
             }
-        };
+        }
     }
 }
 
-impl<FB: FrameBuffer> NativeDisplaySink<FB> {
+impl<FB: FrameBuffer> WinitSink<FB> {
     fn window_attributes(&self) -> WindowAttributes {
         Window::default_attributes()
             .with_title("Pixelflut server (breakwater)")

--- a/breakwater/src/statistics.rs
+++ b/breakwater/src/statistics.rs
@@ -63,7 +63,7 @@ pub struct StatisticsInformationEvent {
     pub statistic_events: u64,
 }
 
-#[allow(clippy::struct_field_names)]
+#[expect(clippy::struct_field_names)]
 pub struct Statistics {
     statistics_rx: mpsc::Receiver<StatisticsEvent>,
     statistics_information_tx: broadcast::Sender<StatisticsInformationEvent>,

--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,7 @@ pkgs.stdenv.mkDerivation rec {
     libvncserver
     libvncserver.dev
 
-    # Needed for native-display feature
+    # Needed for winit/egui features
     wayland
     libGL
     libxkbcommon
@@ -38,7 +38,7 @@ pkgs.stdenv.mkDerivation rec {
   # ndi-sdk-sys's build.rs looks for Processing.NDI.Lib.h here
   NDI_HEADER_DIR = "${ndi}/include";
 
-  # Needed for native-display feature
+  # Needed for winit/egui features
   WINIT_UNIX_BACKEND = "wayland";
   LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath buildInputs}";
   XDG_DATA_DIRS = builtins.getEnv "XDG_DATA_DIRS";


### PR DESCRIPTION
Fixes https://github.com/sbernauer/breakwater/issues/86
CLI args now look like
```bash
Usage: breakwater [OPTIONS]

Options:
  -l, --listener-address <LISTEN_ADDRESSES>
          Listen address to bind to (multiple can be specified). The default value will listen on all interfaces for IPv4 and IPv6 packets [default: [::]:1234]
      --width <WIDTH>
          Width of the drawing surface [default: 1280]
      --height <HEIGHT>
          Height of the drawing surface [default: 720]
  -f, --fps <FPS>
          Frames per second the server should aim for [default: 30]
      --network-buffer-size <NETWORK_BUFFER_SIZE>
          The size in bytes of the network buffer used for each open TCP connection. Please use at least 64 KB (64_000 bytes) [default: 262144]
  -p, --prometheus-listen-address <PROMETHEUS_LISTEN_ADDRESS>
          Listen address the Prometheus exporter should listen on [default: [::]:9100]
      --statistics-save-file <STATISTICS_SAVE_FILE>
          Save file where statistics are periodically saved. The save file will be read during startup and statistics are restored. To reset the statistics simply remove the file [default: statistics.json]
      --statistics-save-interval-s <STATISTICS_SAVE_INTERVAL_S>
          Interval (in seconds) in which the statistics save file should be updated [default: 10]
      --disable-statistics-save-file
          Disable periodical saving of statistics into save file
  -c, --connections-per-ip <CONNECTIONS_PER_IP>
          Allow only a certain number of connections per ip address
      --shared-memory-name <SHARED_MEMORY_NAME>
          Create (or use an existing) shared memory region for the framebuffer. This enables other applications to read and write Pixel values to the framebuffer or can be used to persist the canvas across restarts
  -s, --enable-sink <ENABLED_SINKS>
          Enable an arbitrary number of sinks (argument can be repeated). The availability of sinks depends on the enabled features [possible values: ffmpeg, egui, winit, vnc, ndi]
  -h, --help
          Print help
  -V, --version
          Print version

ffmpeg sink options:
      --ffmpeg-rtmp-address <RTMP_ADDRESS>
          Enable rtmp streaming to configured address, e.g. `rtmp://127.0.0.1:1935/live/test`
      --ffmpeg-video-save-folder <VIDEO_SAVE_FOLDER>
          Enable dump of video stream into file. File location will be `<VIDEO_SAVE_FOLDER>/pixelflut_dump_{timestamp}.mp4`

egui sink options:
      --egui-viewport <VIEWPORTS>
          Specify a view port to display the canvas or a certain part of it. Format: `<offset_x>x<offset_y>,<width>x<height>`. Might be specified multiple times for more than one viewport. Useful for multi-projector setups. Defaults to display the entire canvas
      --egui-advertised-endpoint <ADVERTISED_ENDPOINTS>
          Specify one or more pixelflut endpoints to display
      --egui-ui <UI>
          Provide a path to a dylib containing a custom egui overlay

NDI sink options:
      --ndi-source-name <SOURCE_NAME>  Readable NDI source name [default: "Pixelflut server (breakwater)"]

VNC sink options:
      --vnc-listen-address <VNC_LISTEN_ADDRESSES>
          VNC server listen address to bind to (multiple can be specified). Only one address of each IP version can be specified
      --vnc-text <TEXT>
          Text to display on the screen [default: "Pixelflut server (breakwater)"]
      --vnc-font <FONT>
          The font used to render the text on the screen. Should be a ttf file. If you use the default value a copy that ships with breakwater will be used - no need to download and provide the font [default: Arial.ttf]
```