### PR TITLE
chore: Use upstream ndi-sdk-sys 0.1.1 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.21.1] - 2026-06-18
-
 ### Changed
 
 - Bump `ndi-sdk-sys` to `0.1.1` (instead of a forked version) as it now supports Linux.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.21.1] - 2026-06-18
+
+### Changed
+
+- Bump `ndi-sdk-sys` to `0.1.1` (instead of a forked version) as it now supports Linux.
+  Due to this we now only depend on crates.io crates, so we can push to it again ([#91]).
+
+[#91]: https://github.com/sbernauer/breakwater/pull/91
+
 ## [0.21.0] - 2026-06-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,9 +586,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "calloop"
@@ -2616,8 +2616,9 @@ dependencies = [
 
 [[package]]
 name = "ndi-sdk-sys"
-version = "0.1.0"
-source = "git+https://github.com/kleinesfilmroellchen/rust-ndi-sdk.git?branch=main#a96dfd1bd358bd6e5a9aa12024706295d7cda7af"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a02d95591a221df31af7b4e35e2763242285ad17261cf6848080c09adc8bd856"
 dependencies = [
  "bindgen 0.71.1",
  "num",
@@ -4321,9 +4322,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ local-ip-address = "0.6.3"
 memadvise = "0.1"
 memchr = "2.7"
 number_prefix = "0.4"
-ndi-sdk-sys = { git = "https://github.com/kleinesfilmroellchen/rust-ndi-sdk.git", branch = "main" }
+ndi-sdk-sys = "0.1.1"
 page_size = "0.6"
 pixelbomber = "1.1"
 prometheus_exporter = "0.8"


### PR DESCRIPTION
Pulls in Linux support: https://github.com/deno-plc/rust-ndi-sdk/pull/7